### PR TITLE
Add support for using non-compat Elaboratable instances with some compat functions

### DIFF
--- a/nmigen/compat/fhdl/verilog.py
+++ b/nmigen/compat/fhdl/verilog.py
@@ -4,6 +4,7 @@ from ...hdl.ir import Fragment
 from ...hdl.cd import ClockDomain
 from ...back import verilog
 from .conv_output import ConvOutput
+from .module import Module
 
 
 def convert(fi, ios=None, name="top", special_overrides=dict(),
@@ -17,11 +18,14 @@ def convert(fi, ios=None, name="top", special_overrides=dict(),
                       DeprecationWarning, stacklevel=1)
     # TODO: attr_translate
 
+    if isinstance(fi, Module):
+        fi = fi.get_fragment()
+
     def missing_domain(name):
         if create_clock_domains:
             return ClockDomain(name)
     v_output = verilog.convert(
-        elaboratable=fi.get_fragment(),
+        elaboratable=fi,
         name=name,
         ports=ios or (),
         missing_domain=missing_domain

--- a/nmigen/compat/sim/__init__.py
+++ b/nmigen/compat/sim/__init__.py
@@ -3,6 +3,7 @@ import inspect
 from collections.abc import Iterable
 from ...hdl.cd import ClockDomain
 from ...back.pysim import *
+from ...hdl.ir import Fragment
 
 
 __all__ = ["run_simulation", "passive"]
@@ -17,9 +18,12 @@ def run_simulation(fragment_or_module, generators, clocks={"sync": 10}, vcd_name
     else:
         fragment = fragment_or_module
 
+    fragment = Fragment.get(fragment, platform=None)
+
     if not isinstance(generators, dict):
         generators = {"sync": generators}
-        fragment.domains += ClockDomain("sync")
+        if "sync" not in fragment.domains:
+            fragment.add_domains(ClockDomain("sync"))
 
     sim = Simulator(fragment)
     for domain, period in clocks.items():

--- a/nmigen/test/compat/test_run_simulation.py
+++ b/nmigen/test/compat/test_run_simulation.py
@@ -1,0 +1,26 @@
+import unittest
+from ... import Signal, Module, Elaboratable
+from .support import SimCase
+
+
+class RunSimulation(SimCase, unittest.TestCase):
+    """ test for https://github.com/nmigen/nmigen/issues/344 """
+
+    class TestBench(Elaboratable):
+        def __init__(self):
+            self.a = Signal()
+
+        def elaborate(self, platform):
+            m = Module()
+            m.d.sync += self.a.eq(~self.a)
+            return m
+
+    def test_run_simulation(self):
+        def gen():
+            yield
+            for i in range(10):
+                yield
+                a = (yield self.tb.a)
+                self.assertEqual(a, i % 2)
+
+        self.run_with(gen())


### PR DESCRIPTION
Add support for using non-compat `Elaboratable` instances with `compat.fhdl.verilog.convert` and `compat.run_simulation`

Fixes #344