### PR TITLE
back.pysim performance improvements

### DIFF
--- a/nmigen/hdl/rec.py
+++ b/nmigen/hdl/rec.py
@@ -132,6 +132,13 @@ class Record(Value):
                 else:
                     self.fields[field_name] = Signal(field_shape, name=concat(name, field_name),
                                                      src_loc_at=1 + src_loc_at)
+        self.__key = self._Intern(
+            self,
+            tuple(self.fields[f]._key.properties for f, _, _ in self.layout))
+
+    @property
+    def _key(self):
+        return self.__key
 
     def __getattr__(self, name):
         return self[name]


### PR DESCRIPTION
I'm not sure how high a priority the Python simulation backend is or whether it's worth making the structural changes to hdl.ast to optimize hashing, but I figured I would share what I've figured out so far in case it's useful. Please let me know what you think.

The changes here fall roughly into the following categories:

- Fixing what I believe to be the intent behind curr/next comparisons, and avoiding doing work where (I think) it's known there is no work to be done
- Optimizing the hashing of Value/Signal/Statement key objects, since this is done in a few very frequently traversed code paths
- Caching compilation results (from hdl.ast to what I believe is Python bytecode)
- Micro-optimizations. I think the only one that made it through was the VCD hash table lookup, and it's pretty marginal at this point

I used the following simulation to make performance measurements: [sim_perf_test.py](https://github.com/sjolsen/nmigen-nexys/blob/master/test/sim_perf_test.py). I have perf data for each commit in the chain, both with and without VCD output enabled. I can see about uploading them somewhere if there's interest, but in the meantime here's a summary:

With no VCD output:

Commit | Description | Time elapsed (s) | Reduction (incr.) | Reduction (cum.)
-- | -- | -- | -- | --
bb1bbcc5 | hdl.mem: fix source location of ReadPort.en. | 116.8 | -- | --
52e30bc8 | back.pysim: Fix curr=next optimizations | 90.77 | 22.29% | 22.29%
6902c99a | hdl.ast: Intern value/statement keys off the hot path | 80.74 | 11.05% | 30.87%
642e4774 | back.pysim: Cache compilation results | 32.17 | 60.16% | 72.46%
d1fe3c63 | back.pysim: Reuse clock simulation commands | 25.29 | 21.39% | 78.35%
65405683 | back.pysim: Eliminate duplicate dict lookup in VCD update | 24.88 | 1.62% | 78.70%

With VCD output enabled:

Commit | Description | Time elapsed (s) | Reduction (incr.) | Reduction (cum.)
-- | -- | -- | -- | --
bb1bbcc5 | hdl.mem: fix source location of ReadPort.en. | 152.6 | -- | --
52e30bc8 | back.pysim: Fix curr=next optimizations | 127.4 | 16.51% | 16.51%
6902c99a | hdl.ast: Intern value/statement keys off the hot path | 118 | 7.38% | 22.67%
642e4774 | back.pysim: Cache compilation results | 66.94 | 43.27% | 56.13%
d1fe3c63 | back.pysim: Reuse clock simulation commands | 57.16 | 14.61% | 62.54%
65405683 | back.pysim: Eliminate duplicate dict lookup in VCD update | 53.25 | 6.84% | 65.10%

I did run the nMigen unit tests, but I haven't figured out yet how to set up sby on Windows so I don't know whether those tests are broken by my changes.