### PR TITLE
Fix `_yosys_version()`

### DIFF
--- a/nmigen/back/verilog.py
+++ b/nmigen/back/verilog.py
@@ -16,6 +16,7 @@ class YosysError(Exception):
 def _yosys_version():
     yosys_path = require_tool("yosys")
     version = subprocess.check_output([yosys_path, "-V"], encoding="utf-8")
+    # If Yosys is built with Verific, then Verific license information is printed first.
     m = re.search(r"^Yosys ([\d.]+)(?:\+(\d+))?", version, flags=re.M)
     tag, offset = m[1], m[2] or 0
     return tuple(map(int, tag.split("."))), offset

--- a/nmigen/back/verilog.py
+++ b/nmigen/back/verilog.py
@@ -16,7 +16,7 @@ class YosysError(Exception):
 def _yosys_version():
     yosys_path = require_tool("yosys")
     version = subprocess.check_output([yosys_path, "-V"], encoding="utf-8")
-    m = re.match(r"^Yosys ([\d.]+)(?:\+(\d+))?", version)
+    m = re.search(r"^Yosys ([\d.]+)(?:\+(\d+))?", version, flags=re.M)
     tag, offset = m[1], m[2] or 0
     return tuple(map(int, tag.split("."))), offset
 


### PR DESCRIPTION
`re.match` only matches at the beginning of the string, not each line. This change changes it to do a `re.search` with the multiline flag. I think this is primarily of use when the user has compiled yosys with verific extensions.

Example of `yosys -V` output that failed with the prior code:

```
~/s/nmigen · yosys -V
-- (c) Copyright 1999 - 2020 Verific Design Automation Inc. All rights reserved
-- Compilation time was Fri Feb 28 11:19:43 2020

-- This program will expire on Sun Jun  7 12:19:43 2020

Yosys 0.9+2406 (git sha1 cf716e1f, gcc 8.3.0-6 -Os)
```

Verilog generation is still borked. `yosys -q -` doesn't seem to stop the Verific license from being printed, so it gets captured in the subprocess stdout when nmigen grabs the output from yosys. It might be a bit more foolproof to modify that to write the data to a tempfile instead and pass the file between nmigen/yosys.

```
-- (c) Copyright 1999 - 2020 Verific Design Automation Inc. All rights reserved
-- Compilation time was Fri Feb 28 11:19:43 2020

-- This program will expire on Sun Jun  7 12:19:43 2020

/* Generated by Yosys 0.9+2406 (git sha1 cf716e1f, gcc 8.3.0-6 -Os) */

(* generator = "nMigen" *)
(* top =  1  *)
(* \nmigen.hierarchy  = "top" *)
module top(clk, rst, o);
```