### PR TITLE
Check type of `ports` argument to `convert` functions.

### DIFF
--- a/nmigen/hdl/ir.py
+++ b/nmigen/hdl/ir.py
@@ -532,7 +532,7 @@ class Fragment:
         if ports is None:
             fragment._propagate_ports(ports=(), all_undef_as_ports=True)
         else:
-            # typecheck ports is either list or tuple (#362)
+            # typecheck ports is either list or tuple
             if not isinstance(ports, tuple) and not isinstance(ports, list):
                 msg = "`ports` must be either a list or a tuple, not {!r}"\
                         .format(ports)

--- a/nmigen/hdl/ir.py
+++ b/nmigen/hdl/ir.py
@@ -532,7 +532,6 @@ class Fragment:
         if ports is None:
             fragment._propagate_ports(ports=(), all_undef_as_ports=True)
         else:
-            # typecheck ports is either list or tuple
             if not isinstance(ports, tuple) and not isinstance(ports, list):
                 msg = "`ports` must be either a list or a tuple, not {!r}"\
                         .format(ports)

--- a/nmigen/hdl/ir.py
+++ b/nmigen/hdl/ir.py
@@ -535,9 +535,9 @@ class Fragment:
             # typecheck ports is either list or tuple (#362)
             if not isinstance(ports, tuple) and not isinstance(ports, list):
                 msg = "`ports` must be either a list or a tuple, not {!r}"\
-                        .format(type(ports).__name__)
+                        .format(ports)
                 if isinstance(ports, Value):
-                    msg += " (did you mean `ports=(<signal>,)`?)"
+                    msg += " (did you mean `ports=(<signal>,)`, rather than `ports=<signal>`?)"
                 raise TypeError(msg)
             mapped_ports = []
             # Lower late bound signals like ClockSignal() to ports.

--- a/nmigen/hdl/ir.py
+++ b/nmigen/hdl/ir.py
@@ -532,6 +532,13 @@ class Fragment:
         if ports is None:
             fragment._propagate_ports(ports=(), all_undef_as_ports=True)
         else:
+            # typecheck ports is either list or tuple (#362)
+            if not isinstance(ports, tuple) and not isinstance(ports, list):
+                msg = "`ports` must be either a list or a tuple, not {!r}"\
+                        .format(type(ports).__name__)
+                if isinstance(ports, Value):
+                    msg += " (did you mean `ports=(<signal>,)`?)"
+                raise TypeError(msg)
             mapped_ports = []
             # Lower late bound signals like ClockSignal() to ports.
             port_lowerer = DomainLowerer(fragment.domains)

--- a/nmigen/test/test_hdl_ir.py
+++ b/nmigen/test/test_hdl_ir.py
@@ -304,6 +304,16 @@ class FragmentPortsTestCase(FHDLTestCase):
                 msg="Only signals may be added as ports, not (const 1'd1)"):
             f.prepare(ports=(Const(1),))
 
+    def test_port_not_iterable(self):
+        f = Fragment()
+        with self.assertRaises(TypeError,
+                msg="`ports` must be either a list or a tuple, not 'int'"):
+            f.prepare(ports=1)
+        with self.assertRaises(TypeError,
+                msg="`ports` must be either a list or a tuple, not 'Const'" +
+                " (did you mean `ports=(<signal>,)`?)"):
+            f.prepare(ports=Const(1))
+
 class FragmentDomainsTestCase(FHDLTestCase):
     def test_iter_signals(self):
         cd1 = ClockDomain()

--- a/nmigen/test/test_hdl_ir.py
+++ b/nmigen/test/test_hdl_ir.py
@@ -307,11 +307,11 @@ class FragmentPortsTestCase(FHDLTestCase):
     def test_port_not_iterable(self):
         f = Fragment()
         with self.assertRaises(TypeError,
-                msg="`ports` must be either a list or a tuple, not 'int'"):
+                msg="`ports` must be either a list or a tuple, not 1"):
             f.prepare(ports=1)
         with self.assertRaises(TypeError,
-                msg="`ports` must be either a list or a tuple, not 'Const'" +
-                " (did you mean `ports=(<signal>,)`?)"):
+                msg="`ports` must be either a list or a tuple, not (const 1'd1)" +
+                " (did you mean `ports=(<signal>,)`, rather than `ports=<signal>`?)"):
             f.prepare(ports=Const(1))
 
 class FragmentDomainsTestCase(FHDLTestCase):


### PR DESCRIPTION
The `ports` argument to the `convert` functions is a frequent hotspot of
beginner issues. Check to make sure it is either a list or a tuple, and
give an appropriately helpful error message if not.

Resolves #362 .