### PR TITLE
hdl.rec: don't save casted shapes in Layout constructor

### DIFF
--- a/nmigen/hdl/rec.py
+++ b/nmigen/hdl/rec.py
@@ -47,7 +47,8 @@ class Layout:
                                 .format(field))
             if not isinstance(shape, Layout):
                 try:
-                    shape = Shape.cast(shape, src_loc_at=1 + src_loc_at)
+                    # Check provided shape by calling Shape.cast and checking for exception
+                    Shape.cast(shape, src_loc_at=1 + src_loc_at)
                 except Exception as error:
                     raise TypeError("Field {!r} has invalid shape: should be castable to Shape "
                                     "or a list of fields of a nested record"
@@ -134,7 +135,7 @@ class Record(UserValue):
                 if isinstance(field_shape, Layout):
                     assert isinstance(field, Record) and field_shape == field.layout
                 else:
-                    assert isinstance(field, Signal) and field_shape == field.shape()
+                    assert isinstance(field, Signal) and Shape.cast(field_shape) == field.shape()
                 self.fields[field_name] = field
             else:
                 if isinstance(field_shape, Layout):

--- a/nmigen/test/test_lib_io.py
+++ b/nmigen/test/test_lib_io.py
@@ -5,95 +5,104 @@ from ..back.pysim import *
 from ..lib.io import *
 
 
-class PinLayoutCombTestCase(FHDLTestCase):
+class PinLayoutTestCase(FHDLTestCase):
+    def assertLayoutEqual(self, layout, expected):
+        casted_layout = {}
+        for name, (shape, dir) in layout.items():
+            casted_layout[name] = (Shape.cast(shape), dir)
+
+        self.assertEqual(casted_layout, expected)
+
+
+class PinLayoutCombTestCase(PinLayoutTestCase):
     def test_pin_layout_i(self):
         layout_1 = pin_layout(1, dir="i")
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "i": ((1, False), DIR_NONE),
         })
 
         layout_2 = pin_layout(2, dir="i")
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "i": ((2, False), DIR_NONE),
         })
 
     def test_pin_layout_o(self):
         layout_1 = pin_layout(1, dir="o")
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "o": ((1, False), DIR_NONE),
         })
 
         layout_2 = pin_layout(2, dir="o")
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "o": ((2, False), DIR_NONE),
         })
 
     def test_pin_layout_oe(self):
         layout_1 = pin_layout(1, dir="oe")
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "o":  ((1, False), DIR_NONE),
             "oe": ((1, False), DIR_NONE),
         })
 
         layout_2 = pin_layout(2, dir="oe")
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "o":  ((2, False), DIR_NONE),
             "oe": ((1, False), DIR_NONE),
         })
 
     def test_pin_layout_io(self):
         layout_1 = pin_layout(1, dir="io")
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "i":  ((1, False), DIR_NONE),
             "o":  ((1, False), DIR_NONE),
             "oe": ((1, False), DIR_NONE),
         })
 
         layout_2 = pin_layout(2, dir="io")
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "i":  ((2, False), DIR_NONE),
             "o":  ((2, False), DIR_NONE),
             "oe": ((1, False), DIR_NONE),
         })
 
 
-class PinLayoutSDRTestCase(FHDLTestCase):
+class PinLayoutSDRTestCase(PinLayoutTestCase):
     def test_pin_layout_i(self):
         layout_1 = pin_layout(1, dir="i", xdr=1)
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "i_clk": ((1, False), DIR_NONE),
             "i": ((1, False), DIR_NONE),
         })
 
         layout_2 = pin_layout(2, dir="i", xdr=1)
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "i_clk": ((1, False), DIR_NONE),
             "i": ((2, False), DIR_NONE),
         })
 
     def test_pin_layout_o(self):
         layout_1 = pin_layout(1, dir="o", xdr=1)
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "o_clk": ((1, False), DIR_NONE),
             "o": ((1, False), DIR_NONE),
         })
 
         layout_2 = pin_layout(2, dir="o", xdr=1)
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "o_clk": ((1, False), DIR_NONE),
             "o": ((2, False), DIR_NONE),
         })
 
     def test_pin_layout_oe(self):
         layout_1 = pin_layout(1, dir="oe", xdr=1)
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "o_clk": ((1, False), DIR_NONE),
             "o":  ((1, False), DIR_NONE),
             "oe": ((1, False), DIR_NONE),
         })
 
         layout_2 = pin_layout(2, dir="oe", xdr=1)
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "o_clk": ((1, False), DIR_NONE),
             "o":  ((2, False), DIR_NONE),
             "oe": ((1, False), DIR_NONE),
@@ -101,7 +110,7 @@ class PinLayoutSDRTestCase(FHDLTestCase):
 
     def test_pin_layout_io(self):
         layout_1 = pin_layout(1, dir="io", xdr=1)
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "i_clk": ((1, False), DIR_NONE),
             "i":  ((1, False), DIR_NONE),
             "o_clk": ((1, False), DIR_NONE),
@@ -110,7 +119,7 @@ class PinLayoutSDRTestCase(FHDLTestCase):
         })
 
         layout_2 = pin_layout(2, dir="io", xdr=1)
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "i_clk": ((1, False), DIR_NONE),
             "i":  ((2, False), DIR_NONE),
             "o_clk": ((1, False), DIR_NONE),
@@ -119,17 +128,17 @@ class PinLayoutSDRTestCase(FHDLTestCase):
         })
 
 
-class PinLayoutDDRTestCase(FHDLTestCase):
+class PinLayoutDDRTestCase(PinLayoutTestCase):
     def test_pin_layout_i(self):
         layout_1 = pin_layout(1, dir="i", xdr=2)
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "i_clk": ((1, False), DIR_NONE),
             "i0": ((1, False), DIR_NONE),
             "i1": ((1, False), DIR_NONE),
         })
 
         layout_2 = pin_layout(2, dir="i", xdr=2)
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "i_clk": ((1, False), DIR_NONE),
             "i0": ((2, False), DIR_NONE),
             "i1": ((2, False), DIR_NONE),
@@ -137,14 +146,14 @@ class PinLayoutDDRTestCase(FHDLTestCase):
 
     def test_pin_layout_o(self):
         layout_1 = pin_layout(1, dir="o", xdr=2)
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "o_clk": ((1, False), DIR_NONE),
             "o0": ((1, False), DIR_NONE),
             "o1": ((1, False), DIR_NONE),
         })
 
         layout_2 = pin_layout(2, dir="o", xdr=2)
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "o_clk": ((1, False), DIR_NONE),
             "o0": ((2, False), DIR_NONE),
             "o1": ((2, False), DIR_NONE),
@@ -152,7 +161,7 @@ class PinLayoutDDRTestCase(FHDLTestCase):
 
     def test_pin_layout_oe(self):
         layout_1 = pin_layout(1, dir="oe", xdr=2)
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "o_clk": ((1, False), DIR_NONE),
             "o0": ((1, False), DIR_NONE),
             "o1": ((1, False), DIR_NONE),
@@ -160,7 +169,7 @@ class PinLayoutDDRTestCase(FHDLTestCase):
         })
 
         layout_2 = pin_layout(2, dir="oe", xdr=2)
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "o_clk": ((1, False), DIR_NONE),
             "o0": ((2, False), DIR_NONE),
             "o1": ((2, False), DIR_NONE),
@@ -169,7 +178,7 @@ class PinLayoutDDRTestCase(FHDLTestCase):
 
     def test_pin_layout_io(self):
         layout_1 = pin_layout(1, dir="io", xdr=2)
-        self.assertEqual(layout_1.fields, {
+        self.assertLayoutEqual(layout_1.fields, {
             "i_clk": ((1, False), DIR_NONE),
             "i0": ((1, False), DIR_NONE),
             "i1": ((1, False), DIR_NONE),
@@ -180,7 +189,7 @@ class PinLayoutDDRTestCase(FHDLTestCase):
         })
 
         layout_2 = pin_layout(2, dir="io", xdr=2)
-        self.assertEqual(layout_2.fields, {
+        self.assertLayoutEqual(layout_2.fields, {
             "i_clk": ((1, False), DIR_NONE),
             "i0": ((2, False), DIR_NONE),
             "i1": ((2, False), DIR_NONE),


### PR DESCRIPTION
Don't save the result of Shape.cast in the Layout constructor.
This allows the original user-provided shape to be preserved,
while still checking its validity.

This fixes Enum decoder inference for Signals (#393).