### PR TITLE
vendor/lattice_machxo: suppport machXO3

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ nMigen can be used to target any FPGA or ASIC process that accepts behavioral Ve
 
   * Lattice iCE40 (toolchains: **Yosys+nextpnr**, LSE-iCECube2, Synplify-iCECube2);
   * Lattice MachXO2 (toolchains: Diamond);
-  * Lattice MachXO3l (toolchains: Diamond);
+  * Lattice MachXO3L (toolchains: Diamond);
   * Lattice ECP5 (toolchains: **Yosys+nextpnr**, Diamond);
   * Xilinx Spartan 3A (toolchains: ISE);
   * Xilinx Spartan 6 (toolchains: ISE);

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ nMigen can be used to target any FPGA or ASIC process that accepts behavioral Ve
 
   * Lattice iCE40 (toolchains: **Yosys+nextpnr**, LSE-iCECube2, Synplify-iCECube2);
   * Lattice MachXO2 (toolchains: Diamond);
+  * Lattice MachXO3l (toolchains: Diamond);
   * Lattice ECP5 (toolchains: **Yosys+nextpnr**, Diamond);
   * Xilinx Spartan 3A (toolchains: ISE);
   * Xilinx Spartan 6 (toolchains: ISE);

--- a/nmigen/vendor/lattice_machxo_2_3l.py
+++ b/nmigen/vendor/lattice_machxo_2_3l.py
@@ -4,10 +4,11 @@ from ..hdl import *
 from ..build import *
 
 
-__all__ = ["LatticeMachXO2Platform"]
+__all__ = ["LatticeMachXO2Platform", "LatticeMachXO3lPlatform"]
 
-
-class LatticeMachXO2Platform(TemplatedPlatform):
+# MachXO2 and MachXO3l primitives are the same. Handle both using
+# one class and expose user-aliases for convenience.
+class LatticeMachXO2Or3lPlatform(TemplatedPlatform):
     """
     Required tools:
         * ``pnmainc``
@@ -131,7 +132,7 @@ class LatticeMachXO2Platform(TemplatedPlatform):
     ]
 
     def create_missing_domain(self, name):
-        # Lattice MachXO2 devices have two global set/reset signals: PUR, which is driven at
+        # Lattice MachXO2/MachXO3l devices have two global set/reset signals: PUR, which is driven at
         # startup by the configuration logic and unconditionally resets every storage element,
         # and GSR, which is driven by user logic and each storage element may be configured as
         # affected or unaffected by GSR. PUR is purely asynchronous, so even though it is
@@ -148,8 +149,8 @@ class LatticeMachXO2Platform(TemplatedPlatform):
             gsr0 = Signal()
             gsr1 = Signal()
             m = Module()
-            # There is no end-of-startup signal on MachXO2, but PUR is released after IOB enable,
-            # so a simple reset synchronizer (with PUR as the asynchronous reset) does the job.
+            # There is no end-of-startup signal on MachXO2/MachXO3l, but PUR is released after IOB
+            # enable, so a simple reset synchronizer (with PUR as the asynchronous reset) does the job.
             m.submodules += [
                 Instance("FD1S3AX", p_GSR="DISABLED", i_CK=clk_i, i_D=~rst_i, o_Q=gsr0),
                 Instance("FD1S3AX", p_GSR="DISABLED", i_CK=clk_i, i_D=gsr0,   o_Q=gsr1),
@@ -393,4 +394,7 @@ class LatticeMachXO2Platform(TemplatedPlatform):
             )
         return m
 
-    # CDC primitives are not currently specialized for MachXO2.
+    # CDC primitives are not currently specialized for MachXO2/MachXO3l.
+
+LatticeMachXO2Platform = LatticeMachXO2Or3lPlatform
+LatticeMachXO3lPlatform = LatticeMachXO2Or3lPlatform

--- a/nmigen/vendor/lattice_machxo_2_3l.py
+++ b/nmigen/vendor/lattice_machxo_2_3l.py
@@ -4,11 +4,11 @@ from ..hdl import *
 from ..build import *
 
 
-__all__ = ["LatticeMachXO2Platform", "LatticeMachXO3lPlatform"]
+__all__ = ["LatticeMachXO2Platform", "LatticeMachXO3LPlatform"]
 
-# MachXO2 and MachXO3l primitives are the same. Handle both using
+# MachXO2 and MachXO3L primitives are the same. Handle both using
 # one class and expose user-aliases for convenience.
-class LatticeMachXO2Or3lPlatform(TemplatedPlatform):
+class LatticeMachXO2Or3LPlatform(TemplatedPlatform):
     """
     Required tools:
         * ``pnmainc``
@@ -132,7 +132,7 @@ class LatticeMachXO2Or3lPlatform(TemplatedPlatform):
     ]
 
     def create_missing_domain(self, name):
-        # Lattice MachXO2/MachXO3l devices have two global set/reset signals: PUR, which is driven at
+        # Lattice MachXO2/MachXO3L devices have two global set/reset signals: PUR, which is driven at
         # startup by the configuration logic and unconditionally resets every storage element,
         # and GSR, which is driven by user logic and each storage element may be configured as
         # affected or unaffected by GSR. PUR is purely asynchronous, so even though it is
@@ -149,7 +149,7 @@ class LatticeMachXO2Or3lPlatform(TemplatedPlatform):
             gsr0 = Signal()
             gsr1 = Signal()
             m = Module()
-            # There is no end-of-startup signal on MachXO2/MachXO3l, but PUR is released after IOB
+            # There is no end-of-startup signal on MachXO2/MachXO3L, but PUR is released after IOB
             # enable, so a simple reset synchronizer (with PUR as the asynchronous reset) does the job.
             m.submodules += [
                 Instance("FD1S3AX", p_GSR="DISABLED", i_CK=clk_i, i_D=~rst_i, o_Q=gsr0),
@@ -394,7 +394,7 @@ class LatticeMachXO2Or3lPlatform(TemplatedPlatform):
             )
         return m
 
-    # CDC primitives are not currently specialized for MachXO2/MachXO3l.
+    # CDC primitives are not currently specialized for MachXO2/MachXO3L.
 
-LatticeMachXO2Platform = LatticeMachXO2Or3lPlatform
-LatticeMachXO3lPlatform = LatticeMachXO2Or3lPlatform
+LatticeMachXO2Platform = LatticeMachXO2Or3LPlatform
+LatticeMachXO3LPlatform = LatticeMachXO2Or3LPlatform


### PR DESCRIPTION
machXO2 and machXO3l have same primitives:
- rename file : lattice_machxo2 -> lattice_machxo_2_3l
- rename class: LatticeMachXO2Platform -> LatticeMachXO2Or3lPlatform
- LatticeMachXO2Platform is now an user-alias
- add LatticeMachXO3lPlatform user alias