### PR TITLE
Replace pnmainc with diamondc

### DIFF
--- a/nmigen/vendor/lattice_ecp5.py
+++ b/nmigen/vendor/lattice_ecp5.py
@@ -43,7 +43,7 @@ class LatticeECP5Platform(TemplatedPlatform):
     -----------------
 
     Required tools:
-        * ``pnmainc``
+        * ``diamondc``
         * ``ddtcmd``
 
     The environment is populated by running the script specified in the environment variable
@@ -177,7 +177,7 @@ class LatticeECP5Platform(TemplatedPlatform):
 
     _diamond_required_tools = [
         "yosys",
-        "pnmainc",
+        "diamondc",
         "ddtcmd"
     ]
     _diamond_file_templates = {
@@ -245,7 +245,7 @@ class LatticeECP5Platform(TemplatedPlatform):
     _diamond_command_templates = [
         # These don't have any usable command-line option overrides.
         r"""
-        {{invoke_tool("pnmainc")}}
+        {{invoke_tool("diamondc")}}
             {{name}}.tcl
         """,
         r"""


### PR DESCRIPTION
According to Lattice [support site](http://www.latticesemi.com/en/Support/AnswerDatabase/5/5/2/5522) diamondc sets the env variables required by Lattice tools. pnmainc also tends to fail without emitting logs even when `NMIGEN_verbose=1`.