### PR TITLE
_yosys.py: handle unparseable versions

### DIFF
--- a/nmigen/_yosys.py
+++ b/nmigen/_yosys.py
@@ -53,6 +53,8 @@ class YosysBinary:
 
         Returns
         -------
+        ``None`` if version number could not be determined, or a 3-tuple if it could.
+
         major : int
             Major version.
         minor : int
@@ -151,7 +153,10 @@ class _SystemYosys(YosysBinary):
     def version(cls):
         version = cls.run(["-V"])
         match = re.match(r"^Yosys (\d+)\.(\d+)(?:\+(\d+))?", version)
-        return (int(match[1]), int(match[2]), int(match[3] or 0))
+        if match:
+            return (int(match[1]), int(match[2]), int(match[3] or 0))
+        else:
+            return None
 
     @classmethod
     def data_dir(cls):
@@ -208,8 +213,10 @@ def find_yosys(requirement):
                              "an unrecognized clause {!r}"
                              .format(clause))
     for proxy in proxies:
-        if proxy.available() and requirement(proxy.version()):
-            return proxy
+        if proxy.available():
+            version = proxy.version()
+            if version and requirement(version):
+                return proxy
     else:
         if "NMIGEN_USE_YOSYS" in os.environ:
             raise YosysError("Could not find an acceptable Yosys binary. Searched: {}"

--- a/nmigen/_yosys.py
+++ b/nmigen/_yosys.py
@@ -215,7 +215,7 @@ def find_yosys(requirement):
     for proxy in proxies:
         if proxy.available():
             version = proxy.version()
-            if version and requirement(version):
+            if version is not None and requirement(version):
                 return proxy
     else:
         if "NMIGEN_USE_YOSYS" in os.environ:

--- a/nmigen/_yosys.py
+++ b/nmigen/_yosys.py
@@ -53,7 +53,7 @@ class YosysBinary:
 
         Returns
         -------
-        ``None`` if version number could not be determined, or a 3-tuple if it could.
+        ``None`` if version number could not be determined, or a 3-tuple ``(major, minor, distance)`` if it could.
 
         major : int
             Major version.


### PR DESCRIPTION
Do not use yosys binaries with unparseable version numbers. This ensures
that nmigen always knows what version of yosys it is generating RTLIL
for.

The effect of this change is that if the version number of the system
yosys is unparsable, nmigen will attempt to fallback to the builtin
Yosys.

Issue #409.