### PR TITLE
Update license and copyright info

### DIFF
--- a/CONTRIBUTING.txt
+++ b/CONTRIBUTING.txt
@@ -1,0 +1,23 @@
+CONTRIBUTIONS and CODE REVIEWS
+
+We love contributions from the community. Please send pull requests and raise
+issues! All code submissions require review. We use GitHub pull requests for
+this purpose.
+
+
+COPYRIGHTS and LICENSE
+
+nMigen is licensed under the 2-clause BSD license, which is contained in the
+LICENSE.txt file.
+
+All authors retain copyright ownership of their contributions.
+
+Authors should note that all contributions are licensed under the 2-clause BSD
+license.
+
+
+CONTRIBUTORS
+
+The complete list of contributors is contained within the git repository.
+Tools such as the git log command can be used to see all contributions and
+contributors.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,4 @@
+Copyright (C) 2019-2020 whitequark
 Copyright (C) 2011-2019 M-Labs Limited
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -19,10 +20,3 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-Other authors retain ownership of their contributions. If a submission can
-reasonably be considered independently copyrightable, it's yours and we
-encourage you to claim it with appropriate copyright notices. This submission
-then falls under the "otherwise noted" category. All submissions are strongly
-encouraged to use the two-clause BSD license reproduced above.


### PR DESCRIPTION
Remove non-license explanatory text from LICENSE.txt.

Create CONTRIBUTING file with instructions and notes for contributors.

This change relates to issue #412