### PR TITLE
write next state to vcd instead of curr state, since state is written just prior to commit

### DIFF
--- a/nmigen/sim/pysim.py
+++ b/nmigen/sim/pysim.py
@@ -348,7 +348,7 @@ class Simulator:
             for waveform_writer in self._waveform_writers:
                 for signal_state in self._state.pending:
                     waveform_writer.update(self._state.timeline.now,
-                        signal_state.signal, signal_state.curr)
+                        signal_state.signal, signal_state.next)
 
             # 2. commit: apply every queued signal change, waking up any waiting processes
             converged = self._state.commit()


### PR DESCRIPTION
Fixes #429

I tested it and it seems to work!
@whitequark You can add a regression test later if you want.