### PR TITLE
vendor.xilinx_{7series,ultrascale}: add SIM_DEVICE parameter

### DIFF
--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -168,7 +168,12 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
             ready = Signal()
             m.submodules += Instance("STARTUPE2", o_EOS=ready)
             m.domains += ClockDomain("sync", reset_less=self.default_rst is None)
-            m.submodules += Instance("BUFGCE", i_CE=ready, i_I=clk_i, o_O=ClockSignal("sync"))
+            m.submodules += Instance("BUFGCE",
+                p_SIM_DEVICE="7SERIES",
+                i_CE=ready,
+                i_I=clk_i,
+                o_O=ClockSignal("sync")
+            )
             if self.default_rst is not None:
                 m.submodules.reset_sync = ResetSynchronizer(rst_i, domain="sync")
             return m

--- a/nmigen/vendor/xilinx_ultrascale.py
+++ b/nmigen/vendor/xilinx_ultrascale.py
@@ -168,7 +168,12 @@ class XilinxUltraScalePlatform(TemplatedPlatform):
             ready = Signal()
             m.submodules += Instance("STARTUPE3", o_EOS=ready)
             m.domains += ClockDomain("sync", reset_less=self.default_rst is None)
-            m.submodules += Instance("BUFGCE", i_CE=ready, i_I=clk_i, o_O=ClockSignal("sync"))
+            m.submodules += Instance("BUFGCE",
+                p_SIM_DEVICE="ULTRASCALE",
+                i_CE=ready,
+                i_I=clk_i,
+                o_O=ClockSignal("sync")
+            )
             if self.default_rst is not None:
                 m.submodules.reset_sync = ResetSynchronizer(rst_i, domain="sync")
             return m


### PR DESCRIPTION
The parameter defaults to "ULTRASCALE", even when synthesizing for 7-series devices. This could lead to a simulation/synthesis mismatch, and causes a warning.

Fixes #438.