### PR TITLE
build,vendor: never carry around parts of differential signals

### DIFF
--- a/nmigen/build/plat.py
+++ b/nmigen/build/plat.py
@@ -148,16 +148,15 @@ class Platform(ResourceManager, metaclass=ABCMeta):
             if pin.dir == "io":
                 add_pin_fragment(pin, self.get_input_output(pin, port, attrs, invert))
 
-        for pin, p_port, n_port, attrs, invert in self.iter_differential_pins():
+        for pin, port, attrs, invert in self.iter_differential_pins():
             if pin.dir == "i":
-                add_pin_fragment(pin, self.get_diff_input(pin, p_port, n_port, attrs, invert))
+                add_pin_fragment(pin, self.get_diff_input(pin, port, attrs, invert))
             if pin.dir == "o":
-                add_pin_fragment(pin, self.get_diff_output(pin, p_port, n_port, attrs, invert))
+                add_pin_fragment(pin, self.get_diff_output(pin, port, attrs, invert))
             if pin.dir == "oe":
-                add_pin_fragment(pin, self.get_diff_tristate(pin, p_port, n_port, attrs, invert))
+                add_pin_fragment(pin, self.get_diff_tristate(pin, port, attrs, invert))
             if pin.dir == "io":
-                add_pin_fragment(pin,
-                    self.get_diff_input_output(pin, p_port, n_port, attrs, invert))
+                add_pin_fragment(pin, self.get_diff_input_output(pin, port, attrs, invert))
 
         fragment._propagate_ports(ports=self.iter_ports(), all_undef_as_ports=False)
         return self.toolchain_prepare(fragment, name, **kwargs)
@@ -239,19 +238,19 @@ class Platform(ResourceManager, metaclass=ABCMeta):
         m.d.comb += pin.i.eq(self._invert_if(invert, port))
         return m
 
-    def get_diff_input(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input(self, pin, port, attrs, invert):
         self._check_feature("differential input", pin, attrs,
                             valid_xdrs=(), valid_attrs=None)
 
-    def get_diff_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_output(self, pin, port, attrs, invert):
         self._check_feature("differential output", pin, attrs,
                             valid_xdrs=(), valid_attrs=None)
 
-    def get_diff_tristate(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_tristate(self, pin, port, attrs, invert):
         self._check_feature("differential tristate", pin, attrs,
                             valid_xdrs=(), valid_attrs=None)
 
-    def get_diff_input_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input_output(self, pin, port, attrs, invert):
         self._check_feature("differential input/output", pin, attrs,
                             valid_xdrs=(), valid_attrs=None)
 

--- a/nmigen/build/res.py
+++ b/nmigen/build/res.py
@@ -128,9 +128,15 @@ class ResourceManager:
                     phys_names = phys.names
                     port = Record([("io", len(phys))], name=name)
                 if isinstance(phys, DiffPairs):
-                    phys_names = phys.p.names + phys.n.names
-                    port = Record([("p", len(phys)),
-                                   ("n", len(phys))], name=name)
+                    phys_names = []
+                    record_fields = []
+                    if not self.should_skip_port_component(None, attrs, "p"):
+                        phys_names += phys.p.names
+                        record_fields.append(("p", len(phys)))
+                    if not self.should_skip_port_component(None, attrs, "n"):
+                        phys_names += phys.n.names
+                        record_fields.append(("n", len(phys)))
+                    port = Record(record_fields, name=name)
                 if dir == "-":
                     pin = None
                 else:
@@ -166,14 +172,14 @@ class ResourceManager:
             if pin is None:
                 continue
             if isinstance(res.ios[0], Pins):
-                yield pin, port.io, attrs, res.ios[0].invert
+                yield pin, port, attrs, res.ios[0].invert
 
     def iter_differential_pins(self):
         for res, pin, port, attrs in self._ports:
             if pin is None:
                 continue
             if isinstance(res.ios[0], DiffPairs):
-                yield pin, port.p, port.n, attrs, res.ios[0].invert
+                yield pin, port, attrs, res.ios[0].invert
 
     def should_skip_port_component(self, port, attrs, component):
         return False

--- a/nmigen/test/test_build_res.py
+++ b/nmigen/test/test_build_res.py
@@ -85,10 +85,14 @@ class ResourceManagerTestCase(FHDLTestCase):
         self.assertEqual(ports[1].name, "i2c_0__sda__io")
         self.assertEqual(ports[1].width, 1)
 
-        self.assertEqual(list(self.cm.iter_single_ended_pins()), [
-            (i2c.scl, scl, {}, False),
-            (i2c.sda, sda, {}, False),
-        ])
+        scl_info, sda_info = self.cm.iter_single_ended_pins()
+        self.assertIs(scl_info[0], i2c.scl)
+        self.assertIs(scl_info[1].io, scl)
+        self.assertEqual(scl_info[2], {})
+        self.assertEqual(scl_info[3], False)
+        self.assertIs(sda_info[0], i2c.sda)
+        self.assertIs(sda_info[1].io, sda)
+
         self.assertEqual(list(self.cm.iter_port_constraints()), [
             ("i2c_0__scl__io", ["N10"], {}),
             ("i2c_0__sda__io", ["N11"], {})
@@ -108,9 +112,13 @@ class ResourceManagerTestCase(FHDLTestCase):
         self.assertEqual(n.name, "clk100_0__n")
         self.assertEqual(n.width, clk100.width)
 
-        self.assertEqual(list(self.cm.iter_differential_pins()), [
-            (clk100, p, n, {}, False),
-        ])
+        clk100_info, = self.cm.iter_differential_pins()
+        self.assertIs(clk100_info[0], clk100)
+        self.assertIs(clk100_info[1].p, p)
+        self.assertIs(clk100_info[1].n, n)
+        self.assertEqual(clk100_info[2], {})
+        self.assertEqual(clk100_info[3], False)
+
         self.assertEqual(list(self.cm.iter_port_constraints()), [
             ("clk100_0__p", ["H1"], {}),
             ("clk100_0__n", ["H2"], {}),
@@ -123,15 +131,22 @@ class ResourceManagerTestCase(FHDLTestCase):
         ]
         self.cm.add_resources(new_resources)
 
-        sig_cs = self.cm.request("cs")
-        sig_clk = self.cm.request("clk")
-        port_cs, port_clk_p, port_clk_n = self.cm.iter_ports()
-        self.assertEqual(list(self.cm.iter_single_ended_pins()), [
-            (sig_cs, port_cs, {}, True),
-        ])
-        self.assertEqual(list(self.cm.iter_differential_pins()), [
-            (sig_clk, port_clk_p, port_clk_n, {}, True),
-        ])
+        cs = self.cm.request("cs")
+        clk = self.cm.request("clk")
+        cs_io, clk_p, clk_n = self.cm.iter_ports()
+
+        cs_info, = self.cm.iter_single_ended_pins()
+        self.assertIs(cs_info[0], cs)
+        self.assertIs(cs_info[1].io, cs_io)
+        self.assertEqual(cs_info[2], {})
+        self.assertEqual(cs_info[3], True)
+
+        clk_info, = self.cm.iter_differential_pins()
+        self.assertIs(clk_info[0], clk)
+        self.assertIs(clk_info[1].p, clk_p)
+        self.assertIs(clk_info[1].n, clk_n)
+        self.assertEqual(clk_info[2], {})
+        self.assertEqual(clk_info[3], True)
 
     def test_request_raw(self):
         clk50 = self.cm.request("clk50", 0, dir="-")

--- a/nmigen/vendor/intel.py
+++ b/nmigen/vendor/intel.py
@@ -248,7 +248,7 @@ class IntelPlatform(TemplatedPlatform):
             p_enable_bus_hold="FALSE",
             p_number_of_channels=pin.width,
             p_use_differential_mode="FALSE",
-            i_datain=port,
+            i_datain=port.io,
             o_dataout=self._get_ireg(m, pin, invert)
         )
         return m
@@ -266,7 +266,7 @@ class IntelPlatform(TemplatedPlatform):
             p_use_differential_mode="FALSE",
             p_use_oe="FALSE",
             i_datain=self._get_oreg(m, pin, invert),
-            o_dataout=port,
+            o_dataout=port.io,
         )
         return m
 
@@ -283,7 +283,7 @@ class IntelPlatform(TemplatedPlatform):
             p_use_differential_mode="FALSE",
             p_use_oe="TRUE",
             i_datain=self._get_oreg(m, pin, invert),
-            o_dataout=port,
+            o_dataout=port.io,
             i_oe=self._get_oereg(m, pin)
         )
         return m
@@ -300,36 +300,36 @@ class IntelPlatform(TemplatedPlatform):
             p_number_of_channels=pin.width,
             p_use_differential_mode="FALSE",
             i_datain=self._get_oreg(m, pin, invert),
-            io_dataio=port,
+            io_dataio=port.io,
             o_dataout=self._get_ireg(m, pin, invert),
             i_oe=self._get_oereg(m, pin),
         )
         return m
 
-    def get_diff_input(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input(self, pin, port, attrs, invert):
         self._check_feature("differential input", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         if pin.xdr == 1:
-            p_port.attrs["useioff"] = 1
-            n_port.attrs["useioff"] = 1
+            port.p.attrs["useioff"] = 1
+            port.n.attrs["useioff"] = 1
 
         m = Module()
         m.submodules[pin.name] = Instance("altiobuf_in",
             p_enable_bus_hold="FALSE",
             p_number_of_channels=pin.width,
             p_use_differential_mode="TRUE",
-            i_datain=p_port,
-            i_datain_b=n_port,
+            i_datain=port.p,
+            i_datain_b=port.n,
             o_dataout=self._get_ireg(m, pin, invert)
         )
         return m
 
-    def get_diff_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_output(self, pin, port, attrs, invert):
         self._check_feature("differential output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         if pin.xdr == 1:
-            p_port.attrs["useioff"] = 1
-            n_port.attrs["useioff"] = 1
+            port.p.attrs["useioff"] = 1
+            port.n.attrs["useioff"] = 1
 
         m = Module()
         m.submodules[pin.name] = Instance("altiobuf_out",
@@ -338,17 +338,17 @@ class IntelPlatform(TemplatedPlatform):
             p_use_differential_mode="TRUE",
             p_use_oe="FALSE",
             i_datain=self._get_oreg(m, pin, invert),
-            o_dataout=p_port,
-            o_dataout_b=n_port,
+            o_dataout=port.p,
+            o_dataout_b=port.n,
         )
         return m
 
-    def get_diff_tristate(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_tristate(self, pin, port, attrs, invert):
         self._check_feature("differential tristate", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         if pin.xdr == 1:
-            p_port.attrs["useioff"] = 1
-            n_port.attrs["useioff"] = 1
+            port.p.attrs["useioff"] = 1
+            port.n.attrs["useioff"] = 1
 
         m = Module()
         m.submodules[pin.name] = Instance("altiobuf_out",
@@ -357,18 +357,18 @@ class IntelPlatform(TemplatedPlatform):
             p_use_differential_mode="TRUE",
             p_use_oe="TRUE",
             i_datain=self._get_oreg(m, pin, invert),
-            o_dataout=p_port,
-            o_dataout_b=n_port,
+            o_dataout=port.p,
+            o_dataout_b=port.n,
             i_oe=self._get_oereg(m, pin),
         )
         return m
 
-    def get_diff_input_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input_output(self, pin, port, attrs, invert):
         self._check_feature("differential input/output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         if pin.xdr == 1:
-            p_port.attrs["useioff"] = 1
-            n_port.attrs["useioff"] = 1
+            port.p.attrs["useioff"] = 1
+            port.n.attrs["useioff"] = 1
 
         m = Module()
         m.submodules[pin.name] = Instance("altiobuf_bidir",
@@ -376,8 +376,8 @@ class IntelPlatform(TemplatedPlatform):
             p_number_of_channels=pin.width,
             p_use_differential_mode="TRUE",
             i_datain=self._get_oreg(m, pin, invert),
-            io_dataio=p_port,
-            io_dataio_b=n_port,
+            io_dataio=port.p,
+            io_dataio_b=port.n,
             o_dataout=self._get_ireg(m, pin, invert),
             i_oe=self._get_oereg(m, pin),
         )

--- a/nmigen/vendor/lattice_ecp5.py
+++ b/nmigen/vendor/lattice_ecp5.py
@@ -553,9 +553,9 @@ class LatticeECP5Platform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2, 4, 7), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IB",
-                i_I=port[bit],
+                i_I=port.io[bit],
                 o_O=i[bit]
             )
         return m
@@ -565,10 +565,10 @@ class LatticeECP5Platform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2, 4, 7), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OB",
                 i_I=o[bit],
-                o_O=port[bit]
+                o_O=port.io[bit]
             )
         return m
 
@@ -577,11 +577,11 @@ class LatticeECP5Platform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2, 4, 7), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBZ",
                 i_T=t,
                 i_I=o[bit],
-                o_O=port[bit]
+                o_O=port.io[bit]
             )
         return m
 
@@ -590,63 +590,63 @@ class LatticeECP5Platform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2, 4, 7), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("BB",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
-                io_B=port[bit]
+                io_B=port.io[bit]
             )
         return m
 
-    def get_diff_input(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input(self, pin, port, attrs, invert):
         self._check_feature("differential input", pin, attrs,
                             valid_xdrs=(0, 1, 2, 4, 7), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IB",
-                i_I=p_port[bit],
+                i_I=port.p[bit],
                 o_O=i[bit]
             )
         return m
 
-    def get_diff_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_output(self, pin, port, attrs, invert):
         self._check_feature("differential output", pin, attrs,
                             valid_xdrs=(0, 1, 2, 4, 7), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OB",
                 i_I=o[bit],
-                o_O=p_port[bit],
+                o_O=port.p[bit],
             )
         return m
 
-    def get_diff_tristate(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_tristate(self, pin, port, attrs, invert):
         self._check_feature("differential tristate", pin, attrs,
                             valid_xdrs=(0, 1, 2, 4, 7), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBZ",
                 i_T=t,
                 i_I=o[bit],
-                o_O=p_port[bit],
+                o_O=port.p[bit],
             )
         return m
 
-    def get_diff_input_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input_output(self, pin, port, attrs, invert):
         self._check_feature("differential input/output", pin, attrs,
                             valid_xdrs=(0, 1, 2, 4, 7), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("BB",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
-                io_B=p_port[bit],
+                io_B=port.p[bit],
             )
         return m
 

--- a/nmigen/vendor/lattice_ice40.py
+++ b/nmigen/vendor/lattice_ice40.py
@@ -575,39 +575,39 @@ class LatticeICE40Platform(TemplatedPlatform):
         self._check_feature("single-ended input", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        self._get_io_buffer(m, pin, port, attrs, i_invert=invert)
+        self._get_io_buffer(m, pin, port.io, attrs, i_invert=invert)
         return m
 
     def get_output(self, pin, port, attrs, invert):
         self._check_feature("single-ended output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        self._get_io_buffer(m, pin, port, attrs, o_invert=invert)
+        self._get_io_buffer(m, pin, port.io, attrs, o_invert=invert)
         return m
 
     def get_tristate(self, pin, port, attrs, invert):
         self._check_feature("single-ended tristate", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        self._get_io_buffer(m, pin, port, attrs, o_invert=invert)
+        self._get_io_buffer(m, pin, port.io, attrs, o_invert=invert)
         return m
 
     def get_input_output(self, pin, port, attrs, invert):
         self._check_feature("single-ended input/output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
-        self._get_io_buffer(m, pin, port, attrs, i_invert=invert, o_invert=invert)
+        self._get_io_buffer(m, pin, port.io, attrs, i_invert=invert, o_invert=invert)
         return m
 
-    def get_diff_input(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input(self, pin, port, attrs, invert):
         self._check_feature("differential input", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         # See comment in should_skip_port_component above.
-        self._get_io_buffer(m, pin, p_port, attrs, i_invert=invert)
+        self._get_io_buffer(m, pin, port.p, attrs, i_invert=invert)
         return m
 
-    def get_diff_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_output(self, pin, port, attrs, invert):
         self._check_feature("differential output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
@@ -615,8 +615,8 @@ class LatticeICE40Platform(TemplatedPlatform):
         # output pin. The inverter introduces a delay, so for a non-inverting output pin,
         # an identical delay is introduced by instantiating a LUT. This makes the waveform
         # perfectly symmetric in the xdr=0 case.
-        self._get_io_buffer(m, pin, p_port, attrs, o_invert=    invert, invert_lut=True)
-        self._get_io_buffer(m, pin, n_port, attrs, o_invert=not invert, invert_lut=True)
+        self._get_io_buffer(m, pin, port.p, attrs, o_invert=    invert, invert_lut=True)
+        self._get_io_buffer(m, pin, port.n, attrs, o_invert=not invert, invert_lut=True)
         return m
 
     # Tristate bidirectional buffers are not supported on iCE40 because it requires external

--- a/nmigen/vendor/lattice_machxo_2_3l.py
+++ b/nmigen/vendor/lattice_machxo_2_3l.py
@@ -299,7 +299,7 @@ class LatticeMachXO2Or3LPlatform(TemplatedPlatform):
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert)
         for bit in range(len(port)):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IB",
-                i_I=port[bit],
+                i_I=port.io[bit],
                 o_O=i[bit]
             )
         return m
@@ -312,7 +312,7 @@ class LatticeMachXO2Or3LPlatform(TemplatedPlatform):
         for bit in range(len(port)):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OB",
                 i_I=o[bit],
-                o_O=port[bit]
+                o_O=port.io[bit]
             )
         return m
 
@@ -325,7 +325,7 @@ class LatticeMachXO2Or3LPlatform(TemplatedPlatform):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBZ",
                 i_T=t,
                 i_I=o[bit],
-                o_O=port[bit]
+                o_O=port.io[bit]
             )
         return m
 
@@ -339,58 +339,58 @@ class LatticeMachXO2Or3LPlatform(TemplatedPlatform):
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
-                io_B=port[bit]
+                io_B=port.io[bit]
             )
         return m
 
-    def get_diff_input(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input(self, pin, port, attrs, invert):
         self._check_feature("differential input", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IB",
-                i_I=p_port[bit],
+                i_I=port.p[bit],
                 o_O=i[bit]
             )
         return m
 
-    def get_diff_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_output(self, pin, port, attrs, invert):
         self._check_feature("differential output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OB",
                 i_I=o[bit],
-                o_O=p_port[bit],
+                o_O=port.p[bit],
             )
         return m
 
-    def get_diff_tristate(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_tristate(self, pin, port, attrs, invert):
         self._check_feature("differential tristate", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBZ",
                 i_T=t,
                 i_I=o[bit],
-                o_O=p_port[bit],
+                o_O=port.p[bit],
             )
         return m
 
-    def get_diff_input_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input_output(self, pin, port, attrs, invert):
         self._check_feature("differential input/output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("BB",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
-                io_B=p_port[bit],
+                io_B=port.p[bit],
             )
         return m
 

--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -289,9 +289,9 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IBUF",
-                i_I=port[bit],
+                i_I=port.io[bit],
                 o_O=i[bit]
             )
         return m
@@ -301,10 +301,10 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUF",
                 i_I=o[bit],
-                o_O=port[bit]
+                o_O=port.io[bit]
             )
         return m
 
@@ -313,11 +313,11 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFT",
                 i_T=t,
                 i_I=o[bit],
-                o_O=port[bit]
+                o_O=port.io[bit]
             )
         return m
 
@@ -326,63 +326,63 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IOBUF",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
-                io_IO=port[bit]
+                io_IO=port.io[bit]
             )
         return m
 
-    def get_diff_input(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input(self, pin, port, attrs, invert):
         self._check_feature("differential input", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IBUFDS",
-                i_I=p_port[bit], i_IB=n_port[bit],
+                i_I=port.p[bit], i_IB=port.n[bit],
                 o_O=i[bit]
             )
         return m
 
-    def get_diff_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_output(self, pin, port, attrs, invert):
         self._check_feature("differential output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFDS",
                 i_I=o[bit],
-                o_O=p_port[bit], o_OB=n_port[bit]
+                o_O=port.p[bit], o_OB=port.n[bit]
             )
         return m
 
-    def get_diff_tristate(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_tristate(self, pin, port, attrs, invert):
         self._check_feature("differential tristate", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFTDS",
                 i_T=t,
                 i_I=o[bit],
-                o_O=p_port[bit], o_OB=n_port[bit]
+                o_O=port.p[bit], o_OB=port.n[bit]
             )
         return m
 
-    def get_diff_input_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input_output(self, pin, port, attrs, invert):
         self._check_feature("differential input/output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IOBUFDS",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
-                io_IO=p_port[bit], io_IOB=n_port[bit]
+                io_IO=port.p[bit], io_IOB=port.n[bit]
             )
         return m
 

--- a/nmigen/vendor/xilinx_spartan_3_6.py
+++ b/nmigen/vendor/xilinx_spartan_3_6.py
@@ -318,9 +318,9 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IBUF",
-                i_I=port[bit],
+                i_I=port.io[bit],
                 o_O=i[bit]
             )
         return m
@@ -330,10 +330,10 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUF",
                 i_I=o[bit],
-                o_O=port[bit]
+                o_O=port.io[bit]
             )
         return m
 
@@ -342,11 +342,11 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFT",
                 i_T=t,
                 i_I=o[bit],
-                o_O=port[bit]
+                o_O=port.io[bit]
             )
         return m
 
@@ -355,63 +355,63 @@ class XilinxSpartan3Or6Platform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IOBUF",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
-                io_IO=port[bit]
+                io_IO=port.io[bit]
             )
         return m
 
-    def get_diff_input(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input(self, pin, port, attrs, invert):
         self._check_feature("differential input", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IBUFDS",
-                i_I=p_port[bit], i_IB=n_port[bit],
+                i_I=port.p[bit], i_IB=port.n[bit],
                 o_O=i[bit]
             )
         return m
 
-    def get_diff_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_output(self, pin, port, attrs, invert):
         self._check_feature("differential output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFDS",
                 i_I=o[bit],
-                o_O=p_port[bit], o_OB=n_port[bit]
+                o_O=port.p[bit], o_OB=port.n[bit]
             )
         return m
 
-    def get_diff_tristate(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_tristate(self, pin, port, attrs, invert):
         self._check_feature("differential tristate", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFTDS",
                 i_T=t,
                 i_I=o[bit],
-                o_O=p_port[bit], o_OB=n_port[bit]
+                o_O=port.p[bit], o_OB=port.n[bit]
             )
         return m
 
-    def get_diff_input_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input_output(self, pin, port, attrs, invert):
         self._check_feature("differential input/output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IOBUFDS",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
-                io_IO=p_port[bit], io_IOB=n_port[bit]
+                io_IO=port.p[bit], io_IOB=port.n[bit]
             )
         return m
 

--- a/nmigen/vendor/xilinx_ultrascale.py
+++ b/nmigen/vendor/xilinx_ultrascale.py
@@ -285,9 +285,9 @@ class XilinxUltraScalePlatform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IBUF",
-                i_I=port[bit],
+                i_I=port.io[bit],
                 o_O=i[bit]
             )
         return m
@@ -297,10 +297,10 @@ class XilinxUltraScalePlatform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUF",
                 i_I=o[bit],
-                o_O=port[bit]
+                o_O=port.io[bit]
             )
         return m
 
@@ -309,11 +309,11 @@ class XilinxUltraScalePlatform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFT",
                 i_T=t,
                 i_I=o[bit],
-                o_O=port[bit]
+                o_O=port.io[bit]
             )
         return m
 
@@ -322,63 +322,63 @@ class XilinxUltraScalePlatform(TemplatedPlatform):
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert, o_invert=invert)
-        for bit in range(len(port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IOBUF",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
-                io_IO=port[bit]
+                io_IO=port.io[bit]
             )
         return m
 
-    def get_diff_input(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input(self, pin, port, attrs, invert):
         self._check_feature("differential input", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IBUFDS",
-                i_I=p_port[bit], i_IB=n_port[bit],
+                i_I=port.p[bit], i_IB=port.n[bit],
                 o_O=i[bit]
             )
         return m
 
-    def get_diff_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_output(self, pin, port, attrs, invert):
         self._check_feature("differential output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFDS",
                 i_I=o[bit],
-                o_O=p_port[bit], o_OB=n_port[bit]
+                o_O=port.p[bit], o_OB=port.n[bit]
             )
         return m
 
-    def get_diff_tristate(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_tristate(self, pin, port, attrs, invert):
         self._check_feature("differential tristate", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("OBUFTDS",
                 i_T=t,
                 i_I=o[bit],
-                o_O=p_port[bit], o_OB=n_port[bit]
+                o_O=port.p[bit], o_OB=port.n[bit]
             )
         return m
 
-    def get_diff_input_output(self, pin, p_port, n_port, attrs, invert):
+    def get_diff_input_output(self, pin, port, attrs, invert):
         self._check_feature("differential input/output", pin, attrs,
                             valid_xdrs=(0, 1, 2), valid_attrs=True)
         m = Module()
         i, o, t = self._get_xdr_buffer(m, pin, i_invert=invert, o_invert=invert)
-        for bit in range(len(p_port)):
+        for bit in range(pin.width):
             m.submodules["{}_{}".format(pin.name, bit)] = Instance("IOBUFDS",
                 i_T=t,
                 i_I=o[bit],
                 o_O=i[bit],
-                io_IO=p_port[bit], io_IOB=n_port[bit]
+                io_IO=port.p[bit], io_IOB=port.n[bit]
             )
         return m
 


### PR DESCRIPTION
When a port component is skipped, it should appear neither in the RTL nor in the constraint file. However, passing around components of differential ports explicitly makes that harder.

Fixes #456.
Supersedes #457.