### PR TITLE
back+cli: Add FIRRTL, json and dot backends. Add ability to use them with cli.main

### DIFF
--- a/nmigen/back/dot.py
+++ b/nmigen/back/dot.py
@@ -1,0 +1,34 @@
+from .._toolchain.yosys import *
+from . import rtlil
+from .verilog import _convert_rtlil_text
+import tempfile, os
+
+
+__all__ = ["YosysError", "convert", "convert_fragment"]
+
+
+def _convert_rtlil_text_dot(rtlil_text, *, strip_internal_attrs=False, show_opts=("-stretch", "-colors 42")):
+    # TODO: add option in yosys to output graphviz to stdout
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        prefix = os.path.join(tmpdirname, "tmp")
+        viewer = "cat" if os.name != "nt" else "type"
+
+        write_script = []
+        # TODO: can these procs be improved?
+        write_script.append("proc_mux")
+        write_script.append("proc_clean")
+        write_script.append("show -format dot -prefix {} -viewer {} {}"
+            .format(prefix, viewer, " ".join(show_opts)))
+
+        return _convert_rtlil_text(rtlil_text,
+            strip_internal_attrs=strip_internal_attrs, write_script=write_script)
+
+
+def convert_fragment(*args, strip_internal_attrs=False, **kwargs):
+    rtlil_text, name_map = rtlil.convert_fragment(*args, **kwargs)
+    return _convert_rtlil_text_dot(rtlil_text, strip_internal_attrs=strip_internal_attrs), name_map
+
+
+def convert(*args, strip_internal_attrs=False, **kwargs):
+    rtlil_text = rtlil.convert(*args, **kwargs)
+    return _convert_rtlil_text_dot(rtlil_text, strip_internal_attrs=strip_internal_attrs)

--- a/nmigen/back/firrtl.py
+++ b/nmigen/back/firrtl.py
@@ -1,0 +1,25 @@
+from .._toolchain.yosys import *
+from . import rtlil
+from .verilog import _convert_rtlil_text
+
+
+__all__ = ["YosysError", "convert", "convert_fragment"]
+
+
+def _convert_rtlil_text_firrtl(rtlil_text, *, strip_internal_attrs=False, write_firrtl_opts=()):
+    write_script = []
+    write_script.append("proc_mux") # TODO: can this be improved?
+    write_script.append("write_firrtl {} -".format(" ".join(write_firrtl_opts)))
+
+    return _convert_rtlil_text(rtlil_text,
+        strip_internal_attrs=strip_internal_attrs, write_script=write_script)
+
+
+def convert_fragment(*args, strip_internal_attrs=False, **kwargs):
+    rtlil_text, name_map = rtlil.convert_fragment(*args, **kwargs)
+    return _convert_rtlil_text_firrtl(rtlil_text, strip_internal_attrs=strip_internal_attrs), name_map
+
+
+def convert(*args, strip_internal_attrs=False, **kwargs):
+    rtlil_text = rtlil.convert(*args, **kwargs)
+    return _convert_rtlil_text_firrtl(rtlil_text, strip_internal_attrs=strip_internal_attrs)

--- a/nmigen/back/json.py
+++ b/nmigen/back/json.py
@@ -1,0 +1,25 @@
+from .._toolchain.yosys import *
+from . import rtlil
+from .verilog import _convert_rtlil_text
+
+
+__all__ = ["YosysError", "convert", "convert_fragment"]
+
+
+def _convert_rtlil_text_json(rtlil_text, *, strip_internal_attrs=False, write_json_opts=()):
+    write_script = []
+    write_script.append("proc_mux") # TODO: can this be improved?
+    write_script.append("write_json {}".format(" ".join(write_json_opts)))
+
+    return _convert_rtlil_text(rtlil_text,
+        strip_internal_attrs=strip_internal_attrs, write_script=write_script)
+
+
+def convert_fragment(*args, strip_internal_attrs=False, **kwargs):
+    rtlil_text, name_map = rtlil.convert_fragment(*args, **kwargs)
+    return _convert_rtlil_text_json(rtlil_text, strip_internal_attrs=strip_internal_attrs), name_map
+
+
+def convert(*args, strip_internal_attrs=False, **kwargs):
+    rtlil_text = rtlil.convert(*args, **kwargs)
+    return _convert_rtlil_text_json(rtlil_text, strip_internal_attrs=strip_internal_attrs)

--- a/nmigen/back/verilog.py
+++ b/nmigen/back/verilog.py
@@ -5,7 +5,7 @@ from . import rtlil
 __all__ = ["YosysError", "convert", "convert_fragment"]
 
 
-def _convert_rtlil_text(rtlil_text, *, strip_internal_attrs=False, write_verilog_opts=()):
+def _convert_rtlil_text(rtlil_text, *, strip_internal_attrs=False, write_script=[]):
     # this version requirement needs to be synchronized with the one in setup.py!
     yosys = find_yosys(lambda ver: ver >= (0, 9))
     yosys_version = yosys.version()
@@ -33,7 +33,7 @@ def _convert_rtlil_text(rtlil_text, *, strip_internal_attrs=False, write_verilog
         script.append("attrmap {}".format(" ".join(attr_map)))
         script.append("attrmap -modattr {}".format(" ".join(attr_map)))
 
-    script.append("write_verilog -norename {}".format(" ".join(write_verilog_opts)))
+    script.extend(write_script)
 
     return yosys.run(["-q", "-"], "\n".join(script),
         # At the moment, Yosys always shows a warning indicating that not all processes can be
@@ -42,11 +42,19 @@ def _convert_rtlil_text(rtlil_text, *, strip_internal_attrs=False, write_verilog
         ignore_warnings=True)
 
 
+def _convert_rtlil_text_verilog(rtlil_text, *, strip_internal_attrs=False, write_verilog_opts=()):
+    write_script = []
+    write_script.append("write_verilog -norename {}".format(" ".join(write_verilog_opts)))
+
+    return _convert_rtlil_text(rtlil_text,
+        strip_internal_attrs=strip_internal_attrs, write_script=write_script)
+
+
 def convert_fragment(*args, strip_internal_attrs=False, **kwargs):
     rtlil_text, name_map = rtlil.convert_fragment(*args, **kwargs)
-    return _convert_rtlil_text(rtlil_text, strip_internal_attrs=strip_internal_attrs), name_map
+    return _convert_rtlil_text_verilog(rtlil_text, strip_internal_attrs=strip_internal_attrs), name_map
 
 
 def convert(*args, strip_internal_attrs=False, **kwargs):
     rtlil_text = rtlil.convert(*args, **kwargs)
-    return _convert_rtlil_text(rtlil_text, strip_internal_attrs=strip_internal_attrs)
+    return _convert_rtlil_text_verilog(rtlil_text, strip_internal_attrs=strip_internal_attrs)

--- a/nmigen/cli.py
+++ b/nmigen/cli.py
@@ -1,7 +1,7 @@
 import argparse
 
 from .hdl.ir import Fragment
-from .back import rtlil, cxxrtl, verilog, json, firrtl, pysim
+from .back import rtlil, cxxrtl, verilog, dot, json, firrtl, pysim
 
 
 __all__ = ["main"]
@@ -16,9 +16,9 @@ def main_parser(parser=None):
     p_generate = p_action.add_parser("generate",
         help="generate RTLIL or Verilog from the design")
     p_generate.add_argument("-t", "--type", dest="generate_type",
-        metavar="LANGUAGE", choices=["il", "cc", "v", "json", "fir"],
+        metavar="LANGUAGE", choices=["il", "cc", "v", "dot", "json", "fir"],
         default=None,
-        help="generate LANGUAGE (il for RTLIL, v for Verilog, fir for FIRRTL, json; default: %(default)s)")
+        help="generate LANGUAGE (il for RTLIL, v for Verilog, fir for FIRRTL, dot, json; default: %(default)s)")
     p_generate.add_argument("generate_file",
         metavar="FILE", type=argparse.FileType("w"), nargs="?",
         help="write generated code to FILE")
@@ -52,6 +52,8 @@ def main_runner(parser, args, design, platform=None, name="top", ports=()):
                 generate_type = "cc"
             if args.generate_file.name.endswith(".v"):
                 generate_type = "v"
+            if args.generate_file.name.endswith(".dot"):
+                generate_type = "dot"
             if args.generate_file.name.endswith(".json"):
                 generate_type = "json"
             if args.generate_file.name.endswith(".fir"):
@@ -64,6 +66,8 @@ def main_runner(parser, args, design, platform=None, name="top", ports=()):
             output = cxxrtl.convert(fragment, name=name, ports=ports)
         if generate_type == "v":
             output = verilog.convert(fragment, name=name, ports=ports)
+        if generate_type == "dot":
+            output = dot.convert(fragment, name=name, ports=ports)
         if generate_type == "json":
             output = json.convert(fragment, name=name, ports=ports)
         if generate_type == "fir":

--- a/nmigen/cli.py
+++ b/nmigen/cli.py
@@ -1,7 +1,7 @@
 import argparse
 
 from .hdl.ir import Fragment
-from .back import rtlil, cxxrtl, verilog, firrtl, pysim
+from .back import rtlil, cxxrtl, verilog, json, firrtl, pysim
 
 
 __all__ = ["main"]
@@ -16,9 +16,9 @@ def main_parser(parser=None):
     p_generate = p_action.add_parser("generate",
         help="generate RTLIL or Verilog from the design")
     p_generate.add_argument("-t", "--type", dest="generate_type",
-        metavar="LANGUAGE", choices=["il", "cc", "v", "fir"],
+        metavar="LANGUAGE", choices=["il", "cc", "v", "json", "fir"],
         default=None,
-        help="generate LANGUAGE (il for RTLIL, v for Verilog, fir for FIRRTL; default: %(default)s)")
+        help="generate LANGUAGE (il for RTLIL, v for Verilog, fir for FIRRTL, json; default: %(default)s)")
     p_generate.add_argument("generate_file",
         metavar="FILE", type=argparse.FileType("w"), nargs="?",
         help="write generated code to FILE")
@@ -52,6 +52,8 @@ def main_runner(parser, args, design, platform=None, name="top", ports=()):
                 generate_type = "cc"
             if args.generate_file.name.endswith(".v"):
                 generate_type = "v"
+            if args.generate_file.name.endswith(".json"):
+                generate_type = "json"
             if args.generate_file.name.endswith(".fir"):
                 generate_type = "fir"
         if generate_type is None:
@@ -62,6 +64,8 @@ def main_runner(parser, args, design, platform=None, name="top", ports=()):
             output = cxxrtl.convert(fragment, name=name, ports=ports)
         if generate_type == "v":
             output = verilog.convert(fragment, name=name, ports=ports)
+        if generate_type == "json":
+            output = json.convert(fragment, name=name, ports=ports)
         if generate_type == "fir":
             output = firrtl.convert(fragment, name=name, ports=ports)
         if args.generate_file:

--- a/nmigen/cli.py
+++ b/nmigen/cli.py
@@ -1,7 +1,7 @@
 import argparse
 
 from .hdl.ir import Fragment
-from .back import rtlil, cxxrtl, verilog, pysim
+from .back import rtlil, cxxrtl, verilog, firrtl, pysim
 
 
 __all__ = ["main"]
@@ -16,9 +16,9 @@ def main_parser(parser=None):
     p_generate = p_action.add_parser("generate",
         help="generate RTLIL or Verilog from the design")
     p_generate.add_argument("-t", "--type", dest="generate_type",
-        metavar="LANGUAGE", choices=["il", "cc", "v"],
+        metavar="LANGUAGE", choices=["il", "cc", "v", "fir"],
         default=None,
-        help="generate LANGUAGE (il for RTLIL, v for Verilog; default: %(default)s)")
+        help="generate LANGUAGE (il for RTLIL, v for Verilog, fir for FIRRTL; default: %(default)s)")
     p_generate.add_argument("generate_file",
         metavar="FILE", type=argparse.FileType("w"), nargs="?",
         help="write generated code to FILE")
@@ -52,6 +52,8 @@ def main_runner(parser, args, design, platform=None, name="top", ports=()):
                 generate_type = "cc"
             if args.generate_file.name.endswith(".v"):
                 generate_type = "v"
+            if args.generate_file.name.endswith(".fir"):
+                generate_type = "fir"
         if generate_type is None:
             parser.error("specify file type explicitly with -t")
         if generate_type == "il":
@@ -60,6 +62,8 @@ def main_runner(parser, args, design, platform=None, name="top", ports=()):
             output = cxxrtl.convert(fragment, name=name, ports=ports)
         if generate_type == "v":
             output = verilog.convert(fragment, name=name, ports=ports)
+        if generate_type == "fir":
+            output = firrtl.convert(fragment, name=name, ports=ports)
         if args.generate_file:
             args.generate_file.write(output)
         else:


### PR DESCRIPTION
All of these backends enable you to inspect your design more easily, by using netlistsvg, diagrammer and graphviz.

I did try to expand `ExamplesTestCase` for some coverage on these backends, but it seems like `write_firrtl` in yosys is unable to create the memory defined in `examples/mem.py`. Therefore I left the tests out of this PR for now.