### PR TITLE
hdl.ast.Value: Add .to_signed() method

### DIFF
--- a/docs/lang.rst
+++ b/docs/lang.rst
@@ -664,6 +664,8 @@ Conversion operators
 
 The ``.as_signed()`` and ``.as_unsigned()`` conversion operators reinterpret the bits of a value with the requested signedness. This is useful when the same value is sometimes treated as signed and sometimes as unsigned, or when a signed value is constructed using slices or concatenations. For example, ``(pc + imm[:7].as_signed()).as_unsigned()`` sign-extends the 7 least significant bits of ``imm`` to the width of ``pc``, performs the addition, and produces an unsigned result.
 
+The ``.to_signed()`` conversion operator converts the value to signed, extending it by one bit, to preserve it's numerical value.
+
 .. TODO: more general shape conversion? https://github.com/nmigen/nmigen/issues/381
 
 

--- a/nmigen/hdl/ast.py
+++ b/nmigen/hdl/ast.py
@@ -286,6 +286,19 @@ class Value(metaclass=ABCMeta):
         """
         return Operator("s", [self])
 
+    def to_signed(self):
+        """Conversion to signed, preserving the original value.
+
+        Returns
+        -------
+        Value, out
+            This ``Value`` converted to a signed integer.
+        """
+        if self.shape().signed:
+            return self
+        else:
+            return Cat(self, Const(0)).as_signed()
+
     def bool(self):
         """Conversion to boolean.
 

--- a/nmigen/test/test_hdl_ast.py
+++ b/nmigen/test/test_hdl_ast.py
@@ -358,6 +358,14 @@ class OperatorTestCase(FHDLTestCase):
         self.assertEqual(repr(v), "(s (const 4'd1))")
         self.assertEqual(v.shape(), signed(4))
 
+    def test_to_signed(self):
+        v1 = Const(1, signed(4)).to_signed()
+        self.assertEqual(repr(v1), "(const 4'sd1)")
+        self.assertEqual(v1.shape(), signed(4))
+        v2 = Const(1, unsigned(4)).to_signed()
+        self.assertEqual(repr(v2), "(s (cat (const 4'd1) (const 1'd0)))")
+        self.assertEqual(v2.shape(), signed(5))
+
     def test_neg(self):
         v1 = -Const(0, unsigned(4))
         self.assertEqual(repr(v1), "(- (const 4'd0))")

--- a/nmigen/test/test_sim.py
+++ b/nmigen/test/test_sim.py
@@ -66,6 +66,11 @@ class SimulatorUnitTestCase(FHDLTestCase):
         self.assertStatement(stmt, [C(0b01, unsigned(2)), C(0b0001, signed(4))], C(1))
         self.assertStatement(stmt, [C(0b11, unsigned(2)), C(0b1111, signed(4))], C(1))
 
+    def test_to_signed(self):
+        stmt = lambda y, a, b: y.eq(a.to_signed() == b)
+        self.assertStatement(stmt, [C(0b01, unsigned(2)), C(0b0001, signed(4))], C(1))
+        self.assertStatement(stmt, [C(0b11, unsigned(2)), C(0b0011, signed(4))], C(1))
+
     def test_any(self):
         stmt = lambda y, a: y.eq(a.any())
         self.assertStatement(stmt, [C(0b00, 2)], C(0))


### PR DESCRIPTION
We currently have a `.as_unsigned()`, but if the MSB is set
then its numerical value will be changed by it.

Consider this case for the unsigned variables a and b of same width, where a < b:

```python
a - b               # will underflow
a.as_unsigned() - b # value of a is changed if a[-1] == 1
a.to_unsigned() - b # correct
```