### PR TITLE
Add documentation for how to set up NMIGEN_ENV_Diamond on Windows.

### DIFF
--- a/nmigen/vendor/lattice_ecp5.py
+++ b/nmigen/vendor/lattice_ecp5.py
@@ -47,7 +47,12 @@ class LatticeECP5Platform(TemplatedPlatform):
         * ``ddtcmd``
 
     The environment is populated by running the script specified in the environment variable
-    ``NMIGEN_ENV_Diamond``, if present.
+    ``NMIGEN_ENV_Diamond``, if present. On Linux, diamond_env as provided by Diamond
+    itself is a good candidate. On Windows, the following script (named ``diamond_env.bat``,
+    for instance) is known to work::
+
+        @echo off
+        set PATH=C:\\lscc\\diamond\\%DIAMOND_VERSION%\\bin\\nt64;%PATH%
 
     Available overrides:
         * ``script_project``: inserts commands before ``prj_project save`` in Tcl script.

--- a/nmigen/vendor/lattice_machxo_2_3l.py
+++ b/nmigen/vendor/lattice_machxo_2_3l.py
@@ -16,7 +16,12 @@ class LatticeMachXO2Or3LPlatform(TemplatedPlatform):
         * ``ddtcmd``
 
     The environment is populated by running the script specified in the environment variable
-    ``NMIGEN_ENV_Diamond``, if present.
+    ``NMIGEN_ENV_Diamond``, if present. On Linux, diamond_env as provided by Diamond
+    itself is a good candidate. On Windows, the following script (named ``diamond_env.bat``,
+    for instance) is known to work::
+
+        @echo off
+        set PATH=C:\\lscc\\diamond\\%DIAMOND_VERSION%\\bin\\nt64;%PATH%
 
     Available overrides:
         * ``script_project``: inserts commands before ``prj_project save`` in Tcl script.


### PR DESCRIPTION
Diamond does not provide "`diamond_env.bat`" on Windows. It is up to the user to create their own and point `NMIGEN_ENV_Diamond` to the correct location. I've added an example (with the default install directory `lscc`) of a working script to the documentation.