### PR TITLE
hdl.ir: Update error message for Instance arguments

### DIFF
--- a/nmigen/hdl/ir.py
+++ b/nmigen/hdl/ir.py
@@ -574,7 +574,7 @@ class Instance(Fragment):
                 self.named_ports[name] = (Value.cast(value), kind)
             else:
                 raise NameError("Instance argument {!r} should be a tuple (kind, name, value) "
-                                "where kind is one of \"p\", \"i\", \"o\", or \"io\""
+                                "where kind is one of \"a\", \"p\", \"i\", \"o\", or \"io\""
                                 .format((kind, name, value)))
 
         for kw, arg in kwargs.items():
@@ -590,5 +590,5 @@ class Instance(Fragment):
                 self.named_ports[kw[3:]] = (Value.cast(arg), "io")
             else:
                 raise NameError("Instance keyword argument {}={!r} does not start with one of "
-                                "\"p_\", \"i_\", \"o_\", or \"io_\""
+                                "\"a_\", \"p_\", \"i_\", \"o_\", or \"io_\""
                                 .format(kw, arg))

--- a/tests/test_hdl_ir.py
+++ b/tests/test_hdl_ir.py
@@ -786,14 +786,14 @@ class InstanceTestCase(FHDLTestCase):
         s = Signal()
         with self.assertRaisesRegex(NameError,
                 (r"^Instance argument \('', 's1', \(sig s\)\) should be a tuple "
-                    r"\(kind, name, value\) where kind is one of \"p\", \"i\", \"o\", or \"io\"$")):
+                    r"\(kind, name, value\) where kind is one of \"a\", \"p\", \"i\", \"o\", or \"io\"$")):
             Instance("foo", ("", "s1", s))
 
     def test_wrong_construct_kwarg(self):
         s = Signal()
         with self.assertRaisesRegex(NameError,
                 (r"^Instance keyword argument x_s1=\(sig s\) does not start with one of "
-                    r"\"p_\", \"i_\", \"o_\", or \"io_\"$")):
+                    r"\"a_\", \"p_\", \"i_\", \"o_\", or \"io_\"$")):
             Instance("foo", x_s1=s)
 
     def setUp_cpu(self):


### PR DESCRIPTION
48d4ee4 added the option to specify attributes using Instance arguments, but the error message wasn't updated accordingly.