### PR TITLE
setup.py: Exclude "tests" package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "builtin-yosys": ["nmigen-yosys>=0.9.post3527.*"],
         "remote-build": ["paramiko~=2.7"],
     },
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests*"]),
     entry_points={
         "console_scripts": [
             "nmigen-rpc = nmigen.rpc:main",


### PR DESCRIPTION
67b957d moved the tests from `nmigen/test/` to `tests/`, and removed the `exclude=` parameter from `find_packages()` in setup.py. However, even if the new location is not inside the module tree, it is still found by `find_packages()`, resulting in a stray "tests" module on the system.