### PR TITLE
improve spec directory name of FHDLTestCase

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,7 +28,12 @@ class FHDLTestCase(unittest.TestCase):
         self.assertEqual(prepare_repr(repr(obj)), prepare_repr(repr_str))
 
     def assertFormal(self, spec, mode="bmc", depth=1):
-        caller, *_ = traceback.extract_stack(limit=2)
+        stack = traceback.extract_stack()
+        for frame in reversed(stack):
+            if os.path.dirname(__file__) not in frame.filename:
+                break
+            caller = frame
+
         spec_root, _ = os.path.splitext(caller.filename)
         spec_dir = os.path.dirname(spec_root)
         spec_name = "{}_{}".format(


### PR DESCRIPTION
This PR improves the internal version of FHDLTestCase by trying to get the last stack frame that is still inside the nmigen codebase when creating names for the spec file. This helps to make the FIFO test cases produce all distinct spec directories and makes the nmigen test suite thread-safe (can be run successfully with pytest-xdist)  