### PR TITLE
Handle installation when not running from a full git checkout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ def doc_version():
         return ""
 
     git = parse_git(".")
-    if git.exact:
+    if not git:
+        return ""
+    elif git.exact:
         return git.format_with("{tag}")
     else:
         return "latest"


### PR DESCRIPTION
I'm working on setting up a Nix shell environment, which builds nmigen from a checkout that does not contain a full .git directory. In the this scenario, setuptools_scm is installed correctly, but `parse`/`parse_git` returns `None` because there's no active git checkout.

As a fix, I check to see if `git` is falsey and, if so, return a blank version string. 

I've verified that this installs properly from nix via `fetchFromGithub`