### PR TITLE
lib.fifo.AsyncFFSynchronizer: check input and output signal width

### DIFF
--- a/nmigen/lib/cdc.py
+++ b/nmigen/lib/cdc.py
@@ -128,16 +128,24 @@ class AsyncFFSynchronizer(Elaboratable):
     def __init__(self, i, o, *, o_domain="sync", stages=2, async_edge="pos", max_input_delay=None):
         _check_stages(stages)
 
+        if len(i) != 1:
+            raise ValueError("AsyncFFSynchronizer input width must be 1, not {}"
+                             .format(len(i)))
+        if len(o) != 1:
+            raise ValueError("AsyncFFSynchronizer output width must be 1, not {}"
+                             .format(len(o)))
+
+        if async_edge not in ("pos", "neg"):
+            raise ValueError("AsyncFFSynchronizer async edge must be one of 'pos' or 'neg', "
+                             "not {!r}"
+                             .format(async_edge))
+
         self.i = i
         self.o = o
 
         self._o_domain = o_domain
         self._stages = stages
 
-        if async_edge not in ("pos", "neg"):
-            raise ValueError("AsyncFFSynchronizer async edge must be one of 'pos' or 'neg', "
-                             "not {!r}"
-                             .format(async_edge))
         self._edge = async_edge
 
         self._max_input_delay = max_input_delay

--- a/tests/test_lib_cdc.py
+++ b/tests/test_lib_cdc.py
@@ -69,6 +69,14 @@ class AsyncFFSynchronizerTestCase(FHDLTestCase):
                 r"^AsyncFFSynchronizer async edge must be one of 'pos' or 'neg', not 'xxx'$"):
             AsyncFFSynchronizer(Signal(), Signal(), o_domain="sync", async_edge="xxx")
 
+    def test_width_wrong(self):
+        with self.assertRaisesRegex(ValueError,
+                r"^AsyncFFSynchronizer input width must be 1, not 2$"):
+            AsyncFFSynchronizer(Signal(2), Signal(), o_domain="sync")
+        with self.assertRaisesRegex(ValueError,
+                r"^AsyncFFSynchronizer output width must be 1, not 2$"):
+            AsyncFFSynchronizer(Signal(), Signal(2), o_domain="sync")
+
     def test_pos_edge(self):
         i = Signal()
         o = Signal()


### PR DESCRIPTION
wasted more time than I would like to admit due to this :)