### PR TITLE
Migrate Record to ValueCastable, from UserValue

### DIFF
--- a/nmigen/hdl/rec.py
+++ b/nmigen/hdl/rec.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from collections import OrderedDict
-from functools import reduce
+from functools import reduce, wraps
 
 from .. import tracer
 from .._utils import union, deprecated
@@ -149,7 +149,10 @@ class Record(ValueCastable):
             # it seems we lose the implicit `self` argument at some point, so curry manually
             res = getattr(Value, name)
             if callable(res):
-                return lambda *args, **kwargs: res(self, *args, **kwargs)
+                @wraps(res)
+                def _wrapper(*args, **kwargs):
+                    return res(self, *args, **kwargs)
+                return _wrapper
             return res
         except AttributeError:
             return self[name]

--- a/nmigen/hdl/rec.py
+++ b/nmigen/hdl/rec.py
@@ -145,7 +145,6 @@ class Record(ValueCastable):
     def __getattr__(self, name):
         # must check `getattr` before `self` - we need to hit Value methods before fields
         try:
-            # it seems we lose the implicit `self` argument at some point, so curry manually
             value_attr = getattr(Value, name)
             if callable(value_attr):
                 @wraps(value_attr)

--- a/nmigen/hdl/rec.py
+++ b/nmigen/hdl/rec.py
@@ -147,13 +147,13 @@ class Record(ValueCastable):
         # must check `getattr` before `self` - we need to hit Value methods before fields
         try:
             # it seems we lose the implicit `self` argument at some point, so curry manually
-            res = getattr(Value, name)
-            if callable(res):
-                @wraps(res)
+            value_attr = getattr(Value, name)
+            if callable(value_attr):
+                @wraps(value_attr)
                 def _wrapper(*args, **kwargs):
-                    return res(self, *args, **kwargs)
+                    return value_attr(self, *args, **kwargs)
                 return _wrapper
-            return res
+            return value_attr
         except AttributeError:
             return self[name]
 

--- a/nmigen/hdl/rec.py
+++ b/nmigen/hdl/rec.py
@@ -85,7 +85,6 @@ class Layout:
         return "Layout([{}])".format(", ".join(field_reprs))
 
 
-# Unlike most Values, Record *can* be subclassed.
 class Record(ValueCastable):
     @staticmethod
     def like(other, *, name=None, name_suffix=None, src_loc_at=0):
@@ -190,7 +189,7 @@ class Record(ValueCastable):
         return Cat(self.fields.values())
 
     def __len__(self):
-        return len(Cat(self.fields.values()))
+        return len(self.as_value())
 
     def _lhs_signals(self):
         return union((f._lhs_signals() for f in self.fields.values()), start=SignalSet())

--- a/tests/test_hdl_rec.py
+++ b/tests/test_hdl_rec.py
@@ -135,8 +135,8 @@ class RecordTestCase(FHDLTestCase):
             ("stb",  1),
         ])
 
-        self.assertEqual(repr(r[0]),   "(slice (rec r data stb) 0:1)")
-        self.assertEqual(repr(r[0:3]), "(slice (rec r data stb) 0:3)")
+        self.assertEqual(repr(r[0]),   "(slice (cat (sig r__data) (sig r__stb)) 0:1)")
+        self.assertEqual(repr(r[0:3]), "(slice (cat (sig r__data) (sig r__stb)) 0:3)")
 
     def test_wrong_field(self):
         r = Record([


### PR DESCRIPTION
This PR migrates Record from being based on UserValue to being based on ValueCastable, clearing the way to deprecate UserValue.

Would close #528 .