### PR TITLE
pysim: Run mask on Mux selection operand.

### DIFF
--- a/nmigen/sim/_pyrtl.py
+++ b/nmigen/sim/_pyrtl.py
@@ -177,7 +177,7 @@ class _RHSValueCompiler(_ValueCompiler):
         elif len(value.operands) == 3:
             if value.operator == "m":
                 sel, val1, val0 = value.operands
-                return f"({self(val1)} if {self(sel)} else {self(val0)})"
+                return f"({self(val1)} if {mask(sel)} else {self(val0)})"
         raise NotImplementedError("Operator '{}' not implemented".format(value.operator)) # :nocov:
 
     def on_Slice(self, value):

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -186,6 +186,11 @@ class SimulatorUnitTestCase(FHDLTestCase):
         self.assertStatement(stmt, [C(2, 4), C(3, 4), C(0)], C(3, 4))
         self.assertStatement(stmt, [C(2, 4), C(3, 4), C(1)], C(2, 4))
 
+    def test_mux_mask(self):
+        stmt = lambda y, a, b, c: y.eq(Mux(~c, a, b))
+        self.assertStatement(stmt, [C(2, 4), C(3, 4), C(0)], C(2, 4))
+        self.assertStatement(stmt, [C(2, 4), C(3, 4), C(1)], C(3, 4))
+
     def test_abs(self):
         stmt = lambda y, a: y.eq(abs(a))
         self.assertStatement(stmt, [C(3,  unsigned(8))], C(3,  unsigned(8)))

--- a/tests/test_sim.py
+++ b/tests/test_sim.py
@@ -186,7 +186,7 @@ class SimulatorUnitTestCase(FHDLTestCase):
         self.assertStatement(stmt, [C(2, 4), C(3, 4), C(0)], C(3, 4))
         self.assertStatement(stmt, [C(2, 4), C(3, 4), C(1)], C(2, 4))
 
-    def test_mux_mask(self):
+    def test_mux_invert(self):
         stmt = lambda y, a, b, c: y.eq(Mux(~c, a, b))
         self.assertStatement(stmt, [C(2, 4), C(3, 4), C(0)], C(2, 4))
         self.assertStatement(stmt, [C(2, 4), C(3, 4), C(1)], C(3, 4))


### PR DESCRIPTION
Otherwise it behaves funny when it's eg. the result of operator ~.