### PR TITLE
Implement shape() for Record

### DIFF
--- a/nmigen/hdl/rec.py
+++ b/nmigen/hdl/rec.py
@@ -198,6 +198,9 @@ class Record(ValueCastable):
             name = "<unnamed>"
         return "(rec {} {})".format(name, " ".join(fields))
 
+    def shape(self):
+        return self.as_value().shape()
+
     def connect(self, *subordinates, include=None, exclude=None):
         def rec_name(record):
             if record.name is None:

--- a/tests/test_hdl_rec.py
+++ b/tests/test_hdl_rec.py
@@ -176,6 +176,10 @@ class RecordTestCase(FHDLTestCase):
         self.assertIs(r.stb, ns)
         self.assertIs(r.info, nr)
 
+    def test_shape(self):
+        r1 = Record([("a", 1), ("b", 2)])
+        self.assertEqual(r1.shape(), unsigned(3))
+
     def test_like(self):
         r1 = Record([("a", 1), ("b", 2)])
         r2 = Record.like(r1)


### PR DESCRIPTION
Record lost shape() in the migration to ValueCastable. This PR restores it.