### PR TITLE
AsyncFIFOBuffered {r,w}_level fixes

### DIFF
--- a/nmigen/lib/fifo.py
+++ b/nmigen/lib/fifo.py
@@ -509,7 +509,7 @@ class AsyncFIFOBuffered(Elaboratable, FIFOInterface):
         ]
 
         r_consume_buffered = Signal()
-        m.d.comb += r_consume_buffered.eq(self.r_rdy - self.r_en)
+        m.d.comb += r_consume_buffered.eq((self.r_rdy - self.r_en) & self.r_rdy)
         m.d[self._r_domain] += self.r_level.eq(fifo.r_level + r_consume_buffered)
 
         w_consume_buffered = Signal()

--- a/nmigen/lib/fifo.py
+++ b/nmigen/lib/fifo.py
@@ -513,7 +513,7 @@ class AsyncFIFOBuffered(Elaboratable, FIFOInterface):
         m.d[self._r_domain] += self.r_level.eq(fifo.r_level + r_consume_buffered)
 
         w_consume_buffered = Signal()
-        m.submodules.consume_buffered_cdc = FFSynchronizer(r_consume_buffered, w_consume_buffered, o_domain=self._w_domain)
+        m.submodules.consume_buffered_cdc = FFSynchronizer(r_consume_buffered, w_consume_buffered, o_domain=self._w_domain, stages=4)
         m.d.comb += self.w_level.eq(fifo.w_level + w_consume_buffered)
 
         with m.If(self.r_en | ~self.r_rdy):

--- a/nmigen/lib/fifo.py
+++ b/nmigen/lib/fifo.py
@@ -513,7 +513,7 @@ class AsyncFIFOBuffered(Elaboratable, FIFOInterface):
         m.d[self._r_domain] += self.r_level.eq(fifo.r_level + r_consume_buffered)
 
         w_consume_buffered = Signal()
-        m.submodules.consume_buffered_cdc = AsyncFFSynchronizer(r_consume_buffered, w_consume_buffered, o_domain=self._w_domain)
+        m.submodules.consume_buffered_cdc = FFSynchronizer(r_consume_buffered, w_consume_buffered, o_domain=self._w_domain)
         m.d.comb += self.w_level.eq(fifo.w_level + w_consume_buffered)
 
         with m.If(self.r_en | ~self.r_rdy):

--- a/tests/test_lib_fifo.py
+++ b/tests/test_lib_fifo.py
@@ -312,16 +312,16 @@ class AsyncFIFOSimCase(FHDLTestCase):
             for i in range(fill_in):
                 yield fifo.w_data.eq(i)
                 yield fifo.w_en.eq(1)
-                yield
+                yield Tick("write")
             yield fifo.w_en.eq(0)
-            yield
-            yield
+            yield Tick("write")
+            yield Tick("write")
             self.assertEqual((yield fifo.w_level), expected_level)
             yield write_done.eq(1)
 
         def read_process():
             while not (yield write_done):
-                yield
+                yield Tick("read")
             self.assertEqual((yield fifo.r_level), expected_level)
 
         simulator = Simulator(fifo)

--- a/tests/test_lib_fifo.py
+++ b/tests/test_lib_fifo.py
@@ -344,6 +344,10 @@ class AsyncFIFOSimCase(FHDLTestCase):
         fifo = AsyncFIFOBuffered(width=32, depth=9, r_domain="read", w_domain="write")
         self.check_async_fifo_level(fifo, fill_in=5, expected_level=5)
 
+    def test_async_buffered_fifo_level_only_three(self):
+        fifo = AsyncFIFOBuffered(width=32, depth=9, r_domain="read", w_domain="write")
+        self.check_async_fifo_level(fifo, fill_in=3, expected_level=3)
+
     def test_async_buffered_fifo_level_full(self):
         fifo = AsyncFIFOBuffered(width=32, depth=9, r_domain="read", w_domain="write")
         self.check_async_fifo_level(fifo, fill_in=10, expected_level=9)

--- a/tests/test_lib_fifo.py
+++ b/tests/test_lib_fifo.py
@@ -305,7 +305,7 @@ class AsyncFIFOSimCase(FHDLTestCase):
         simulator.add_sync_process(testbench)
         simulator.run()
 
-    def check_async_fifo_level(self, fifo, fill_in, expected_level):
+    def check_async_fifo_level(self, fifo, fill_in, expected_level, read=False):
         write_done = Signal()
 
         def write_process():
@@ -320,6 +320,8 @@ class AsyncFIFOSimCase(FHDLTestCase):
             yield write_done.eq(1)
 
         def read_process():
+            if read:
+                yield fifo.r_en.eq(1)
             while not (yield write_done):
                 yield Tick("read")
             self.assertEqual((yield fifo.r_level), expected_level)
@@ -351,3 +353,7 @@ class AsyncFIFOSimCase(FHDLTestCase):
     def test_async_buffered_fifo_level_full(self):
         fifo = AsyncFIFOBuffered(width=32, depth=9, r_domain="read", w_domain="write")
         self.check_async_fifo_level(fifo, fill_in=10, expected_level=9)
+
+    def test_async_buffered_fifo_level_empty(self):
+        fifo = AsyncFIFOBuffered(width=32, depth=9, r_domain="read", w_domain="write")
+        self.check_async_fifo_level(fifo, fill_in=0, expected_level=0, read=True)


### PR DESCRIPTION
This includes a number of fixes for `{r,w}_level` in AsyncFIFOBuffered.

1. The accounting for the output register used `AsyncFFSynchronizer` instead of `FFSynchronizer`. This is wrong as we want to synchronize both edges
2. Use the proper clock domains in the tests (not really a bug in the fifo logic obviously)
3. The FFSynchronizer should have a latency of 4 to match the latency of `consume_w_bin` / `w_level`. Two cycles for the `FFSynchronizer` from the read to the write domain of `consume_w_gry`, one for the `GrayDecoder` and one for the `w_level` calculation.
4. Fix the output register accounting. If the user asserts `r_en` even if `r_rdy` is low, we get `-1` in the intermediate calculation which overflows to `1` as we have a unsigned `Signal`

Let me know if I should split this into multiple PRs or elaborate more on the fixes. The last two include additional testcases that fail without the fix. I did not include a testcase for the `AsyncFFSynchronizer` to `FFSynchronizer` change, as this is obviously wrong and would be hard to properly test without proper multi clock support in formal.