### PR TITLE
Remove outdated comment in ECP5 platform

### DIFF
--- a/nmigen/vendor/lattice_ecp5.py
+++ b/nmigen/vendor/lattice_ecp5.py
@@ -518,7 +518,6 @@ class LatticeECP5Platform(TemplatedPlatform):
             if pin.dir in ("oe", "io"):
                 t = ~pin.oe
         elif pin.xdr == 1:
-            # Note that currently nextpnr will not pack an FF (*FS1P3DX) into the PIO.
             if "i" in pin.dir:
                 get_ireg(pin.i_clk, i, pin_i)
             if "o" in pin.dir:


### PR DESCRIPTION
Starting with nextpnr c6401413a, nextpnr does pack *FS1P3DX into IOLOGIC cells.