### PR TITLE
docs: Update up_counter to avoid deprecation warning

### DIFF
--- a/docs/_code/up_counter.py
+++ b/docs/_code/up_counter.py
@@ -41,7 +41,7 @@ class UpCounter(Elaboratable):
 
         return m
 # --- TEST ---
-from nmigen.back.pysim import Simulator
+from nmigen.sim import Simulator
 
 
 dut = UpCounter(25)


### PR DESCRIPTION
nmigen/docs/_code/up_counter.py:44: DeprecationWarning: instead of nmigen.back.pysim.*, use nmigen.sim.*
  from nmigen.back.pysim import Simulator