### PR TITLE
vendor.lattice_ecp5: correctly generate OE signaling when xdr=0

### DIFF
--- a/nmigen/vendor/lattice_ecp5.py
+++ b/nmigen/vendor/lattice_ecp5.py
@@ -526,7 +526,7 @@ class LatticeECP5Platform(TemplatedPlatform):
             if "o" in pin.dir:
                 o = pin_o
             if pin.dir in ("oe", "io"):
-                t = ~pin.oe
+                t = Repl(~pin.oe, pin.width)
         elif pin.xdr == 1:
             if "i" in pin.dir:
                 get_ireg(pin.i_clk, i, pin_i)


### PR DESCRIPTION
This fixes a logic bug introduced in 6ce2b21e196a0f93b82748ed046098331d20b3bf.