### PR TITLE
compat.genlib.roundrobin: fix missing imports

### DIFF
--- a/nmigen/compat/genlib/roundrobin.py
+++ b/nmigen/compat/genlib/roundrobin.py
@@ -1,3 +1,6 @@
+import warnings
+
+from ..fhdl.structure import Signal, If, Case
 from ..._utils import deprecated
 from ..fhdl.module import CompatModule
 


### PR DESCRIPTION
This fixes some missing imports in the code introduced in commit 20f9ab9