### PR TITLE
Add run_script to build options

### DIFF
--- a/nmigen/build/plat.py
+++ b/nmigen/build/plat.py
@@ -96,7 +96,7 @@ class Platform(ResourceManager, metaclass=ABCMeta):
         if not do_build:
             return plan
 
-        products = plan.execute_local(build_dir)
+        products = plan.execute_local(build_dir, run_script=kwargs.get("run_script", True))
         if not do_program:
             return products
 


### PR DESCRIPTION
When iterating it's convenient to have the project files updated without running the full synth/impl loop. This PR propagates the top-level `run_script` argument to the execution phase.