### PR TITLE
Add synth_design_options override for vivado

### DIFF
--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -108,7 +108,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                 read_xdc {{file|tcl_escape}}
             {% endfor %}
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
-            synth_design -top {{name}}
+            synth_design -top {{name}} {{get_override("synth_design_options")|default("# (synth_design_options placeholder)")}}
             foreach cell [get_cells -quiet -hier -filter {nmigen.vivado.false_path == "TRUE"}] {
                 set_false_path -to $cell
             }

--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -109,7 +109,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                 read_xdc {{file|tcl_escape}}
             {% endfor %}
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
-            synth_design -top {{name}} {{get_override("synth_design_opts")|default("# (synth_design_opts placeholder)")}}
+            synth_design -top {{name}} {{get_override("synth_design_opts")}}
             foreach cell [get_cells -quiet -hier -filter {nmigen.vivado.false_path == "TRUE"}] {
                 set_false_path -to $cell
             }

--- a/nmigen/vendor/xilinx_7series.py
+++ b/nmigen/vendor/xilinx_7series.py
@@ -21,6 +21,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
 
     Available overrides:
         * ``script_after_read``: inserts commands after ``read_xdc`` in Tcl script.
+        * ``synth_design_opts``: sets options for ``synth_design``.
         * ``script_after_synth``: inserts commands after ``synth_design`` in Tcl script.
         * ``script_after_place``: inserts commands after ``place_design`` in Tcl script.
         * ``script_after_route``: inserts commands after ``route_design`` in Tcl script.
@@ -108,7 +109,7 @@ class Xilinx7SeriesPlatform(TemplatedPlatform):
                 read_xdc {{file|tcl_escape}}
             {% endfor %}
             {{get_override("script_after_read")|default("# (script_after_read placeholder)")}}
-            synth_design -top {{name}} {{get_override("synth_design_options")|default("# (synth_design_options placeholder)")}}
+            synth_design -top {{name}} {{get_override("synth_design_opts")|default("# (synth_design_opts placeholder)")}}
             foreach cell [get_cells -quiet -hier -filter {nmigen.vivado.false_path == "TRUE"}] {
                 set_false_path -to $cell
             }


### PR DESCRIPTION
Apparently the only way to pass options for synthesis in Vivado non-project mode is to add the arguments to the synth_design tcl command directly.

This PR adds an override to the xilinx_7series.py.

One use case is to inspect the synthesized design in Vivado with the following overrides in `platform.build`:
```
        synth_design_options="-flatten_hierarchy none -keep_equivalent_registers -no_lc",
        script_after_synth="write_checkpoint -force top.dcp",
```

There might be a more elegant/generic way of doing this for other workflows/platforms (environment variables?).