### PR TITLE
Properly raise SyntaxError for various mis-nested If/Elif/Else statements

### DIFF
--- a/nmigen/hdl/dsl.py
+++ b/nmigen/hdl/dsl.py
@@ -226,6 +226,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
         cond = self._check_signed_cond(cond)
         src_loc = tracer.get_src_loc(src_loc_at=1)
         if_data = self._set_ctrl("If", {
+            "depth":    self.domain._depth,
             "tests":    [],
             "bodies":   [],
             "src_loc":  src_loc,
@@ -249,7 +250,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
         cond = self._check_signed_cond(cond)
         src_loc = tracer.get_src_loc(src_loc_at=1)
         if_data = self._get_ctrl("If")
-        if if_data is None or len(if_data["tests"]) == 0:
+        if if_data is None or if_data["depth"] != self.domain._depth:
             raise SyntaxError("Elif without preceding If")
         try:
             _outer_case, self._statements = self._statements, []
@@ -268,7 +269,7 @@ class Module(_ModuleBuilderRoot, Elaboratable):
         self._check_context("Else", context=None)
         src_loc = tracer.get_src_loc(src_loc_at=1)
         if_data = self._get_ctrl("If")
-        if if_data is None:
+        if if_data is None or if_data["depth"] != self.domain._depth:
             raise SyntaxError("Else without preceding If/Elif")
         try:
             _outer_case, self._statements = self._statements, []

--- a/tests/test_hdl_dsl.py
+++ b/tests/test_hdl_dsl.py
@@ -281,6 +281,34 @@ class DSLTestCase(FHDLTestCase):
             with m.Else():
                 pass
 
+    def test_Else_wrong_nested(self):
+        m = Module()
+        with m.If(self.s1):
+            with self.assertRaisesRegex(SyntaxError,
+                    r"^Else without preceding If/Elif$"):
+                with m.Else():
+                    pass
+
+    def test_Elif_Elif_wrong_nested(self):
+        m = Module()
+        with m.If(self.s1):
+            pass
+        with m.Elif(self.s2):
+            with self.assertRaisesRegex(SyntaxError,
+                    r"^Elif without preceding If$"):
+                with m.Elif(self.s3):
+                    pass
+
+    def test_Else_Else_wrong_nested(self):
+        m = Module()
+        with m.If(self.s1):
+            pass
+        with m.Else():
+            with self.assertRaisesRegex(SyntaxError,
+                    r"^Else without preceding If/Elif$"):
+                with m.Else():
+                    pass
+
     def test_If_wide(self):
         m = Module()
         with m.If(self.w1):

--- a/tests/test_hdl_dsl.py
+++ b/tests/test_hdl_dsl.py
@@ -504,6 +504,15 @@ class DSLTestCase(FHDLTestCase):
                 with m.If(self.s2):
                     pass
 
+    def test_Case_wrong_nested(self):
+        m = Module()
+        with m.Switch(self.s1):
+            with m.Case(0):
+                with self.assertRaisesRegex(SyntaxError,
+                    r"^Case is not permitted outside of Switch$"):
+                    with m.Case(1):
+                        pass
+
     def test_FSM_basic(self):
         a = Signal()
         b = Signal()
@@ -659,6 +668,23 @@ class DSLTestCase(FHDLTestCase):
                         r"it is permitted inside of FSM State$")):
                 with m.If(self.s2):
                     pass
+
+    def test_State_outside_FSM_wrong(self):
+        m = Module()
+        with self.assertRaisesRegex(SyntaxError,
+            r"^FSM State is not permitted outside of FSM"):
+            with m.State("FOO"):
+                pass
+
+
+    def test_FSM_State_wrong_nested(self):
+        m = Module()
+        with m.FSM():
+            with m.State("FOO"):
+                with self.assertRaisesRegex(SyntaxError,
+                    r"^FSM State is not permitted outside of FSM"):
+                    with m.State("BAR"):
+                        pass
 
     def test_auto_pop_ctrl(self):
         m = Module()


### PR DESCRIPTION
This patch generalizes the fixes to #500 to correctly raise `SyntaxError` instead of silently doing the wrong thing for the statements `Elif` inside `If`, `Else` inside `If`, `Elif` inside `Elif`, and `Else` inside `Else`.

There are also new tests for these cases. Additionally there are new tests to verify the correct SyntaxError for `Case` inside `Case`, `State` outside of `FSM`, and `State` inside `State` (though their behavior was already correct and was not changed).