### PR TITLE
_toolchain: substitute '+' with 'X' in tool_env_var().

### DIFF
--- a/nmigen/_toolchain/__init__.py
+++ b/nmigen/_toolchain/__init__.py
@@ -10,7 +10,7 @@ class ToolNotFound(Exception):
 
 
 def tool_env_var(name):
-    return name.upper().replace("-", "_")
+    return name.upper().replace("-", "_").replace("+", "X")
 
 
 def _get_tool(name):


### PR DESCRIPTION
`tool_env_var("g++")` returns `"G++"`, which is not a valid environment variable name.