### PR TITLE
Change the character used for constraint hierarchy

### DIFF
--- a/nmigen/vendor/xilinx.py
+++ b/nmigen/vendor/xilinx.py
@@ -276,7 +276,7 @@ class XilinxPlatform(TemplatedPlatform):
             {% endfor %}
             {% for net_signal, port_signal, frequency in platform.iter_clock_constraints() -%}
                 NET "{{net_signal|hierarchy("/")}}" TNM_NET="PRD{{net_signal|hierarchy("/")}}";
-                TIMESPEC "TS{{net_signal|hierarchy("/")}}"=PERIOD "PRD{{net_signal|hierarchy("/")}}" {{1000000000/frequency}} ns HIGH 50%;
+                TIMESPEC "TS{{net_signal|hierarchy("__")}}"=PERIOD "PRD{{net_signal|hierarchy("/")}}" {{1000000000/frequency}} ns HIGH 50%;
             {% endfor %}
             {{get_override("add_constraints")|default("# (add_constraints placeholder)")}}
         """


### PR DESCRIPTION
This patch was proposed by whitequark originally:
https://freenode.irclog.whitequark.org/nmigen/2021-04-10#29646879

I came across an issue when instantiating a PLL inside a submodule. The generated clock constraint by nMigen would  have `/` characters in the string, which caused errors in ISE. Changing the character to `__` fixed the problem.